### PR TITLE
fix: ポップアップ後もPythonがDockに残り最前面アプリになる問題を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ source .venv/bin/activate
 仮想環境を有効にした状態で、本ツールの動作に必要な外部ライブラリをインストールします。
 
 ```bash
-pip install watchdog google-genai pyyaml python-dotenv PyQt6
+pip install watchdog google-genai pyyaml python-dotenv PyQt6 pyobjc-framework-Cocoa pyobjc-framework-Quartz pyobjc-framework-Vision
 ```
 
 **【インストールされる主なパッケージ】**
@@ -46,6 +46,7 @@ pip install watchdog google-genai pyyaml python-dotenv PyQt6
 - `PyQt6`: 高速かつ洗練されたGUIポップアップダイアログ
 - `pyyaml`: `config.yaml` の読み込み
 - `python-dotenv`: `.env` ファイルからのAPIキー読み込み
+- `pyobjc-framework-*`: Vision framework によるOCR（Cocoa / Quartz / Vision）
 
 
 ## 🔐 3. APIキーの設定 (Configuration)

--- a/popup_ui.py
+++ b/popup_ui.py
@@ -1,6 +1,7 @@
 import sys
+from AppKit import NSApplication, NSApplicationActivationPolicyAccessory
 from PyQt6.QtWidgets import (
-    QApplication, QDialog, QVBoxLayout, QLabel, 
+    QApplication, QDialog, QVBoxLayout, QLabel,
     QHBoxLayout, QFrame
 )
 from PyQt6.QtCore import QTimer, Qt
@@ -152,6 +153,21 @@ class RenameDialog(QDialog):
 
 def show_rename_dialog(candidates, timeout_seconds=10):
     app = QApplication.instance() or QApplication(sys.argv)
+
+    # QApplicationを生成するとプロセスが通常のGUIアプリ扱いになり、Dockアイコンと
+    # メニューバーを占有したまま常駐してしまう。メニューバー常駐アプリと同じ
+    # Accessory に変更し、Dockに居座らせない。
+    ns_app = NSApplication.sharedApplication()
+    ns_app.setActivationPolicy_(NSApplicationActivationPolicyAccessory)
+
     dialog = RenameDialog(candidates, timeout_seconds)
+    # Accessoryではウィンドウが自動で前面に来ないため、明示的にフォーカスを取る
+    dialog.show()
+    dialog.raise_()
+    dialog.activateWindow()
     dialog.exec()
+
+    # 閉じた後は前面から退き、フォーカスを元のアプリへ返す
+    ns_app.deactivate()
+
     return dialog.selected_name


### PR DESCRIPTION
## 概要

リネームのポップアップを閉じた後も、PythonがDock（ゴミ箱の隣）にアイコンとして残り、メニューバーも最前面アプリのままになる問題を修正した。手動でPythonを終了するか他のアプリをクリックしないと操作の邪魔になっていた。

Fixes #5

## 原因

`popup_ui.py` の `show_rename_dialog()` が生成する `QApplication` により、macOS上でプロセスが通常のGUIアプリ（`NSApplicationActivationPolicyRegular`）扱いになる。その結果Dockにアイコンが出て、メニューバーがPythonのものに切り替わる。

`main.py` は常駐監視プロセスであり `QApplication` はプロセス終了まで破棄されないため、**初回のポップアップ表示以降、Pythonがずっとアクティブなアプリとして居座り続けていた**。

#1（APIタイムアウト）と #2（ファイルハンドルの解放）はいずれも実在するバグだったが、当初報告されていた「Pythonが動いていてファイルを触れない」の直接の原因はこちら。#3 のアイドルタイムアウトもデフォルト30分経つまではDockに残るため、解決になっていなかった。

## 変更内容

### fix(ui): PythonをDockに居座らせない
- `NSApplicationActivationPolicyAccessory` を設定し、メニューバー常駐アプリと同じ扱いにした。Dockアイコンとメニューバーの占有が発生しなくなる。
- Accessoryではウィンドウが自動で前面に来ないため、`show()` / `raise_()` / `activateWindow()` で明示的にフォーカスを取得。`↑`/`↓`/`Enter` のキーボード操作を維持する。
- ダイアログを閉じた後に `deactivate()` を呼び、フォーカスを元のアプリへ返す。

PyObjCは `ocr_engine.py` で既に使用しており、`AppKit` は同じ `pyobjc-framework-Cocoa` に含まれるため追加依存は発生しない。

### docs(readme): 不足していたpyobjc依存の追記
- `pip install` に `pyobjc-framework-Cocoa` / `Quartz` / `Vision` を追加。`ocr_engine.py` が以前から必要としていたにもかかわらず記載が漏れており、新規環境ではOCRが動かない状態だった。

## 検証

- **検証済み（Linuxサンドボックス / AppKit・PyQt6をスタブ化）**
  - `Accessory設定 → show / raise_ / activateWindow → exec → deactivate` の順で呼ばれること
  - 選択結果が呼び出し元へ正しく返ること
  - 構文チェック（`py_compile`）

- **未検証（Mac実機での確認が必要）**
  - **最重要**: ポップアップが前面に表示され、`↑`/`↓`/`Enter` のキーボード操作が効くか。Accessory化によりフォーカスが取得できなくなると候補選択自体ができなくなるため、ここが崩れる場合は方式変更が必要。
  - Dock（ゴミ箱の隣）にPythonアイコンが表示されないこと
  - ダイアログを閉じた後、Finder等の元のアプリへフォーカスが戻ること
  - 追加した pyobjc 3パッケージが既存環境で問題ないこと

## リリース

マージ後、CLAUDE.md のタグ運用ルールに従い `main` 上で `v1.0.2` を想定。使い方自体は変わらないためPATCH。利用者側の再設定は不要。

## 後続

このPRの実機確認・マージ後、以下の順で着手する。

- #7 リネームダイアログに画像プレビューを表示
- #6 手動リネームモードの追加

いずれも `popup_ui.py` を触るため、本PRで土台を固めてから進める。