### PR TITLE
手動リネームモード・PDF対応・UI刷新・レインボーカーソル修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,12 +4,14 @@
 
 macOSで撮影したスクリーンショットを `watchdog` で検知し、Vision framework のOCRとGemini APIでファイル名候補を生成、PyQt6のポップアップで選択させてリネーム・移動する常駐ツール。
 
+監視による自動リネームに加え、`--rename` で任意のファイル・フォルダをその場でリネームする手動モードを持つ。
+
 | ファイル | 役割 |
 | --- | --- |
-| `main.py` | ファイル監視、処理キュー、全体のフロー制御 |
-| `ocr_engine.py` | Vision framework によるOCR |
+| `main.py` | ファイル監視、処理キュー、CLI、全体のフロー制御 |
+| `ocr_engine.py` | Vision framework によるOCR、PDFのテキスト抽出とページ描画 |
 | `llm_client.py` | Gemini APIへのファイル名候補リクエスト |
-| `popup_ui.py` | PyQt6のリネーム候補ダイアログ |
+| `popup_ui.py` | PyQt6のリネーム候補ダイアログ、Qtイベントループの管理 |
 | `config.yaml` | 全ての設定値と命名規則プロンプト |
 
 **設定値をコードにハードコードしないこと。** 監視先・保存先・タイムアウト・モデル名・命名規則は全て `config.yaml` に集約する。

--- a/README.md
+++ b/README.md
@@ -111,13 +111,14 @@ python main.py --rename ~/Downloads          # フォルダ直下のファイル
 
 1. **ショートカット.app** を開き、新規ショートカットを作成
 2. 「クイックアクション」として登録し、**受け取る項目を「ファイルとフォルダ」**、**「Finder」から使用可能** に設定
+
+   ※ この設定項目の名前・場所はmacOSのバージョンによって変わる。上記はおおよその目安として、実際の画面の文言に従うこと
 3. アクション「**シェルスクリプトを実行**」を追加し、以下を設定
-   - 入力: **ショートカットの入力**
    - 入力の引き渡し方法: **引数として**
-   - シェルスクリプト:
+   - シェルスクリプト（`/path/to/screenshot_renamer` は実際にこのプロジェクトを置いた場所に置き換える）:
 
 ```bash
-cd /Users/cygnu/Documents/screenshot_renamer
+cd /path/to/screenshot_renamer
 .venv/bin/python main.py --rename "$@"
 ```
 
@@ -125,7 +126,11 @@ cd /Users/cygnu/Documents/screenshot_renamer
 
    この名前がFinderの右クリックメニューにそのまま表示されます。
 
-Finderでファイルやフォルダを選んで右クリック →「クイックアクション」から実行できます。
+5. ショートカットを保存しても右クリックメニューに出てこない場合、**システム設定 → 一般 → 機能拡張**（またはmacOSのバージョンによっては「プライバシーとセキュリティ → 機能拡張」）にある **Finder関連の拡張機能一覧** を開き、作成したショートカットにチェックが入っているか確認する
+
+   ※ この項目はGUI操作の自動化・実機確認ができていない。見つからない場合はmacOSのバージョンに応じて「機能拡張」を検索するか、システム設定内を確認すること。
+
+Finderでファイルやフォルダを選んで右クリック →「クイックアクション」から実行できます。メニューに出てこない場合は、Finderを再起動（`Option`キーを押しながらDockのFinderアイコンを右クリック → 「終了」、または `killall Finder`）してみてください。
 
 ※ Desktop / Documents / Downloads 配下のファイルを操作するには、実行するPythonに**フルディスクアクセス**の許可が必要になる場合があります（システム設定 → プライバシーとセキュリティ → フルディスクアクセス）。
 
@@ -148,7 +153,7 @@ cat << 'PLIST_EOF' > ~/Library/LaunchAgents/com.user.screenshot_renamer.plist
     <array>
         <string>/usr/bin/osascript</string>
         <string>-e</string>
-        <string>do shell script "cd /Users/cygnu/Documents/screenshot_renamer && .venv/bin/python main.py > app.log 2> app_error.log"</string>
+        <string>do shell script "cd /path/to/screenshot_renamer && .venv/bin/python main.py > app.log 2> app_error.log"</string>
     </array>
 
     <key>RunAtLoad</key>
@@ -164,7 +169,7 @@ cat << 'PLIST_EOF' > ~/Library/LaunchAgents/com.user.screenshot_renamer.plist
     <!-- 監視ディレクトリに変更があった時（＝スクショ撮影時）に launchd が再起動する -->
     <key>WatchPaths</key>
     <array>
-        <string>/Users/cygnu/Desktop</string>
+        <string>/Users/your-username/Desktop</string>
     </array>
 
     <key>LimitLoadToSessionType</key>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Screenshot Auto-Renamer
+# Smart Renamer
 
 Macで撮影したスクリーンショットをリアルタイムに自動検知し、Google Gemini (3.1 Flash Lite) のOCR機能とLLMを活用して、内容（領収書、財務データ、学習教材など）に合わせた最適なファイル名を提案・自動リネームするバックグラウンドツールです。
 
@@ -23,7 +23,7 @@ PyQt6によるポップアップUIからキーボード（`↑`/`↓`/`Enter`）
 
 ```bash
 # プロジェクトのディレクトリに移動
-cd ~/Documents/screenshot_renamer
+cd ~/Documents/smart-renamer
 
 # 仮想環境（.venv）を作成
 python3 -m venv .venv
@@ -55,7 +55,7 @@ pip install watchdog google-genai pyyaml python-dotenv PyQt6 pyobjc-framework-Co
 
 セキュリティを確保するため、APIキーはGitの管理対象外である `.env` ファイルに保存します。
 
-1. プロジェクトのルートディレクトリ（`~/Documents/screenshot_renamer`）に `.env` という名前のファイルを作成します。
+1. プロジェクトのルートディレクトリ（`~/Documents/smart-renamer`）に `.env` という名前のファイルを作成します。
 2. 取得したGoogle Gemini APIキーを以下のように記述して保存してください。
 
 ```env
@@ -115,10 +115,10 @@ python main.py --rename ~/Downloads          # フォルダ直下のファイル
    ※ この設定項目の名前・場所はmacOSのバージョンによって変わる。上記はおおよその目安として、実際の画面の文言に従うこと
 3. アクション「**シェルスクリプトを実行**」を追加し、以下を設定
    - 入力の引き渡し方法: **引数として**
-   - シェルスクリプト（`/path/to/screenshot_renamer` は実際にこのプロジェクトを置いた場所に置き換える）:
+   - シェルスクリプト（`/path/to/smart-renamer` は実際にこのプロジェクトを置いた場所に置き換える）:
 
 ```bash
-cd /path/to/screenshot_renamer
+cd /path/to/smart-renamer
 .venv/bin/python main.py --rename "$@"
 ```
 
@@ -141,19 +141,19 @@ Finderでファイルやフォルダを選んで右クリック →「クイッ�
 ### 6-1. launchd 用設定ファイル (.plist) の作成
 
 ```bash
-cat << 'PLIST_EOF' > ~/Library/LaunchAgents/com.user.screenshot_renamer.plist
+cat << 'PLIST_EOF' > ~/Library/LaunchAgents/com.user.smart_renamer.plist
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "[http://www.apple.com/DTDs/PropertyList-1.0.dtd](http://www.apple.com/DTDs/PropertyList-1.0.dtd)">
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>com.user.screenshot_renamer</string>
+    <string>com.user.smart_renamer</string>
 
     <key>ProgramArguments</key>
     <array>
         <string>/usr/bin/osascript</string>
         <string>-e</string>
-        <string>do shell script "cd /path/to/screenshot_renamer && .venv/bin/python main.py > app.log 2> app_error.log"</string>
+        <string>do shell script "cd /path/to/smart-renamer && .venv/bin/python main.py > app.log 2> app_error.log"</string>
     </array>
 
     <key>RunAtLoad</key>
@@ -189,19 +189,19 @@ PLIST_EOF
 chmod 755 ~/Library/LaunchAgents
 
 # ユーザーセッションへ登録・起動
-launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.user.screenshot_renamer.plist
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.user.smart_renamer.plist
 ```
 
 ### 6-3. 管理用コマンド
-動作確認: `launchctl list | grep screenshot_renamer` または `ps aux | grep main.py`
+動作確認: `launchctl list | grep smart_renamer` または `ps aux | grep main.py`
 
-サービス停止: `launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.user.screenshot_renamer.plist`
+サービス停止: `launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.user.smart_renamer.plist`
 
 再読み込み:
 
 ```bash
-launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.user.screenshot_renamer.plist
-launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.user.screenshot_renamer.plist
+launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.user.smart_renamer.plist
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.user.smart_renamer.plist
 ```
 
 ログ確認: `cat app_error.log`

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ PyQt6によるポップアップUIからキーボード（`↑`/`↓`/`Enter`）
 - **自動フォールバック**: API制限やタイムアウト発生時は、日付＋4桁連番（例: `2026-07-21__0001_Capture.png`）で自動保存。
 - **超軽量常駐 (launchd)**: macOS標準のバックグラウンド管理（`launchd`）に対応。待機時CPU/GPU消費 0.0%、メモリ約20〜30MBの省電力設計。
 - **アイドルタイムアウト**: 一定時間スクショが無ければ自動終了し、常駐プロセスを残さない（`config.yaml` の `ui.idle_timeout_minutes`、デフォルト30分）。次のスクショ撮影時に `launchd` の `WatchPaths` で自動復帰。
+- **プレビュー表示**: リネーム候補と一緒に対象ファイルの中身を表示。ウィンドウは自由にリサイズでき、サイズは次回に引き継がれる。
+- **手動リネーム**: `--rename` で任意のファイル・フォルダをその場でリネーム。Finderの右クリックからも実行可能。候補の選択に加えて**自分で名前を書き換えられる**。`pdf` / `jpg` / `heic` にも対応。
 
 
 ## 🚀 1. 仮想環境の作成と有効化
@@ -88,11 +90,48 @@ python main.py
 
 ツールの実行を終了したい場合は、ターミナル上で `Ctrl + C` を押してください。
 
-## ⚙️ 5. macOS ログイン時自動常駐化 (launchd)
+### 既存ファイルを手動でリネームする
+
+他のフォルダにあるファイルや、一度リネームしたファイルを付け直したい場合は `--rename` を使います。
+
+```bash
+python main.py --rename ~/Documents/Screenshots/2026-08-18__SBI__口座管理_Capture.png
+python main.py --rename ~/Downloads          # フォルダ直下のファイルをまとめて
+```
+
+- 対応形式は `png` / `jpg` / `jpeg` / `heic` / `pdf`
+- **その場でリネームします。** 監視モードと違い `save_dir` へは移動しません
+- フォルダを渡した場合、**直下のファイルのみ**が対象です（サブフォルダは見ません）
+- タイムアウトはありません。候補を選ぶか、**編集欄で自分で書き換えて** `Enter` で確定します
+- 複数件のときは `3 / 50` の進捗が出ます。`Esc` でその1件をスキップ、「すべて中止」で残り全部を中止
+
+## 🖱 5. Finderの右クリックからリネームする（Quick Action）
+
+`--rename` をFinderの右クリックメニューに登録すると、ファイルを選んで即リネームできます。
+
+1. **ショートカット.app** を開き、新規ショートカットを作成
+2. 「クイックアクション」として登録し、**受け取る項目を「ファイルとフォルダ」**、**「Finder」から使用可能** に設定
+3. アクション「**シェルスクリプトを実行**」を追加し、以下を設定
+   - 入力: **ショートカットの入力**
+   - 入力の引き渡し方法: **引数として**
+   - シェルスクリプト:
+
+```bash
+cd /Users/cygnu/Documents/screenshot_renamer
+.venv/bin/python main.py --rename "$@"
+```
+
+4. ショートカットに名前を付けて保存（例: `AIでリネーム`）
+
+Finderでファイルやフォルダを選んで右クリック →「クイックアクション」から実行できます。
+
+※ Desktop / Documents / Downloads 配下のファイルを操作するには、実行するPythonに**フルディスクアクセス**の許可が必要になる場合があります（システム設定 → プライバシーとセキュリティ → フルディスクアクセス）。
+
+## ⚙️ 6. macOS ログイン時自動常駐化 (launchd)
 
 手動起動せず、Mac起動時にバックグラウンドで完全自動実行させる設定です。
 
-### 5-1. launchd 用設定ファイル (.plist) の作成
+### 6-1. launchd 用設定ファイル (.plist) の作成
 
 ```bash
 cat << 'PLIST_EOF' > ~/Library/LaunchAgents/com.user.screenshot_renamer.plist
@@ -137,7 +176,7 @@ PLIST_EOF
 
 ※ `WatchPaths` のパスは `config.yaml` の `watch_dir` と一致させてください（`~` は展開されないため絶対パスで記述します）。
 
-### 5-2. 権限設定と常駐登録
+### 6-2. 権限設定と常駐登録
 ```bash
 # フォルダ権限の許可
 chmod 755 ~/Library/LaunchAgents
@@ -146,7 +185,7 @@ chmod 755 ~/Library/LaunchAgents
 launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.user.screenshot_renamer.plist
 ```
 
-### 5-3. 管理用コマンド
+### 6-3. 管理用コマンド
 動作確認: `launchctl list | grep screenshot_renamer` または `ps aux | grep main.py`
 
 サービス停止: `launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.user.screenshot_renamer.plist`

--- a/README.md
+++ b/README.md
@@ -121,7 +121,9 @@ cd /Users/cygnu/Documents/screenshot_renamer
 .venv/bin/python main.py --rename "$@"
 ```
 
-4. ショートカットに名前を付けて保存（例: `AIでリネーム`）
+4. ショートカットに名前を付けて保存（例: `Rename with Gemini`）
+
+   この名前がFinderの右クリックメニューにそのまま表示されます。
 
 Finderでファイルやフォルダを選んで右クリック →「クイックアクション」から実行できます。
 

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ import os
 # Tkinterの非推奨警告（DeprecationWarning）を非表示にする設定
 os.environ["TK_SILENCE_DEPRECATION"] = "1"
 
+import argparse
 import time
 import shutil
 import yaml
@@ -15,7 +16,7 @@ from dotenv import load_dotenv
 # .envファイルから環境変数を読み込む
 load_dotenv()
 
-from ocr_engine import extract_text
+from ocr_engine import extract_text, is_supported
 from llm_client import get_filename_candidates
 from popup_ui import run_event_loop, show_rename_dialog, stop_event_loop
 
@@ -106,6 +107,80 @@ def get_next_sequence_name(save_dir):
     return f"{today_str}__{next_seq:04d}_Capture"
 
 
+def collect_targets(paths):
+    """CLIで渡されたパスを、リネーム対象のファイル一覧に展開する。
+
+    フォルダは直下のみを見る。再帰すると意図せず大量のファイルを拾い、
+    そのぶんAPIを呼んでしまうため。
+    """
+    targets = []
+    for path in paths:
+        if os.path.isdir(path):
+            entries = sorted(os.listdir(path))
+            candidates = [os.path.join(path, name) for name in entries]
+        else:
+            candidates = [path]
+
+        for candidate in candidates:
+            filename = os.path.basename(candidate)
+            if filename.startswith('.') or not os.path.isfile(candidate):
+                continue
+            if is_supported(candidate) and candidate not in targets:
+                targets.append(candidate)
+
+    return targets
+
+
+def rename_manually(paths, config):
+    """選ばれたファイルをその場でリネームする（移動しない）。"""
+    targets = collect_targets(paths)
+    if not targets:
+        print("対象になるファイルがありません（対応形式: png / jpg / jpeg / heic / pdf）")
+        return
+
+    prompt_template = config['llm_rules']['prompt_template']
+    total = len(targets)
+    print(f"🗂 {total}件のファイルをリネームします")
+
+    for index, filepath in enumerate(targets, start=1):
+        print(f"\n[{index}/{total}] {filepath}")
+        candidates = build_candidates(filepath, prompt_template)
+
+        if not candidates:
+            # 手動モードでは連番より、元の名前を出して直してもらう方が親切
+            candidates = [os.path.splitext(os.path.basename(filepath))[0]]
+            print("⚠️ 候補を取得できませんでした。元のファイル名を表示します。")
+        else:
+            print(f"✨ 取得した候補: {candidates}")
+
+        final_name, aborted = show_rename_dialog(
+            candidates,
+            filepath,
+            timeout_seconds=None,      # 自分で決める必要があるためタイムアウトしない
+            progress=(index, total),
+            foreground=True,           # 自分で起動しているので前面に出す
+        )
+
+        if aborted:
+            print("⏹ 残りを中止しました。")
+            return
+
+        if final_name:
+            # 移動はせず、元のフォルダの中で名前だけ変える
+            apply_rename(filepath, final_name, os.path.dirname(filepath))
+        else:
+            print("↩︎ スキップしました。")
+
+
+def build_candidates(filepath, prompt_template):
+    """OCR/テキスト抽出からファイル名候補までをまとめる。監視・手動の共通処理。"""
+    print("🔍 テキストを抽出中...")
+    text = extract_text(filepath)
+
+    print("🧠 LLMへファイル名候補をリクエスト中...")
+    return get_filename_candidates(text, prompt_template)
+
+
 def process_screenshot(filepath, config):
     # OSによるファイル書き込み完了を待つため1秒待機
     time.sleep(1.0)
@@ -116,14 +191,10 @@ def process_screenshot(filepath, config):
     save_dir = os.path.expanduser(config['directories']['save_dir'])
     timeout = config['ui']['timeout_seconds']
     prompt_template = config['llm_rules']['prompt_template']
-    
+
     os.makedirs(save_dir, exist_ok=True)
 
-    print("🔍 OCR処理を実行中...")
-    text = extract_text(filepath)
-
-    print("🧠 LLMへファイル名候補をリクエスト中...")
-    candidates = get_filename_candidates(text, prompt_template)
+    candidates = build_candidates(filepath, prompt_template)
 
     if not candidates:
         final_name = get_next_sequence_name(save_dir)
@@ -161,13 +232,33 @@ def apply_rename(filepath, final_name, dest_dir):
         return None
 
 
-if __name__ == "__main__":
+def load_config():
+    # 実行ディレクトリに依存せず、スクリプトと同じ場所の設定を読む
+    config_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "config.yaml")
     try:
-        with open("config.yaml", "r", encoding="utf-8") as f:
-            config = yaml.safe_load(f)
+        with open(config_path, "r", encoding="utf-8") as f:
+            return yaml.safe_load(f)
     except FileNotFoundError:
-        print("エラー: config.yaml が見つかりません。")
+        print(f"エラー: config.yaml が見つかりません。({config_path})")
         exit(1)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="スクリーンショットのリネームツール")
+    parser.add_argument(
+        "--rename",
+        nargs="+",
+        metavar="PATH",
+        help="指定したファイル（またはフォルダ直下のファイル）をその場でリネームする",
+    )
+    args = parser.parse_args()
+
+    config = load_config()
+
+    # 手動モード: 常駐せず、渡されたファイルを処理して終了する
+    if args.rename:
+        rename_manually(args.rename, config)
+        exit(0)
 
     watch_dir = os.path.expanduser(config['directories']['watch_dir'])
     idle_timeout = config['ui'].get('idle_timeout_minutes', 0) * 60

--- a/main.py
+++ b/main.py
@@ -132,7 +132,7 @@ def process_screenshot(filepath, config):
         print(f"✨ 取得した候補: {candidates}")
         print("🖥️ UIを表示します...")
         # 単一のTkウィンドウとしてダイアログを起動
-        final_name = show_rename_dialog(candidates, filepath, timeout_seconds=timeout)
+        final_name, _ = show_rename_dialog(candidates, filepath, timeout_seconds=timeout)
         
     if final_name:
         apply_rename(filepath, final_name, save_dir)

--- a/main.py
+++ b/main.py
@@ -118,7 +118,7 @@ def process_screenshot(filepath, config):
         print(f"✨ 取得した候補: {candidates}")
         print("🖥️ UIを表示します...")
         # 単一のTkウィンドウとしてダイアログを起動
-        final_name = show_rename_dialog(candidates, timeout_seconds=timeout)
+        final_name = show_rename_dialog(candidates, filepath, timeout_seconds=timeout)
         
     if final_name:
         new_filename = f"{final_name}.png"

--- a/main.py
+++ b/main.py
@@ -121,22 +121,30 @@ def process_screenshot(filepath, config):
         final_name = show_rename_dialog(candidates, filepath, timeout_seconds=timeout)
         
     if final_name:
-        new_filename = f"{final_name}.png"
-        dest_path = os.path.join(save_dir, new_filename)
-
-        # 同名ファイルが存在する場合の重複回避 (_1, _2 ...)
-        counter = 1
-        while os.path.exists(dest_path):
-            dest_path = os.path.join(save_dir, f"{final_name}_{counter}.png")
-            counter += 1
-
-        try:
-            shutil.move(filepath, dest_path)
-            print(f"✅ 保存完了: {dest_path}\n")
-        except Exception as e:
-            print(f"❌ ファイル移動エラー: {e}")
+        apply_rename(filepath, final_name, save_dir)
     else:
         print("⚠️ キャンセルされました。ファイルは元の場所に残ります。\n")
+
+
+def apply_rename(filepath, final_name, dest_dir):
+    """元の拡張子を保ったままリネームして dest_dir へ移す。"""
+    # 拡張子を決め打ちすると、PNG以外を渡したときに壊れたファイル名になる
+    extension = os.path.splitext(filepath)[1]
+    dest_path = os.path.join(dest_dir, f"{final_name}{extension}")
+
+    # 同名ファイルが存在する場合の重複回避 (_1, _2 ...)
+    counter = 1
+    while os.path.exists(dest_path):
+        dest_path = os.path.join(dest_dir, f"{final_name}_{counter}{extension}")
+        counter += 1
+
+    try:
+        shutil.move(filepath, dest_path)
+        print(f"✅ 保存完了: {dest_path}\n")
+        return dest_path
+    except Exception as e:
+        print(f"❌ ファイル移動エラー: {e}")
+        return None
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ load_dotenv()
 
 from ocr_engine import extract_text
 from llm_client import get_filename_candidates
-from popup_ui import show_rename_dialog
+from popup_ui import run_event_loop, show_rename_dialog, stop_event_loop
 
 file_queue = queue.Queue()
 processed_files = set()  # 重複処理防止用のセット
@@ -161,21 +161,33 @@ if __name__ == "__main__":
     print(f"👀 監視を開始しました: {watch_dir}")
     print("終了する場合は Ctrl+C を押してください。")
 
-    # メインの軽量監視ループ（0.5秒おきにキューをチェック）
-    last_activity = time.time()
-    try:
-        while True:
-            try:
-                filepath = file_queue.get_nowait()
-                process_screenshot(filepath, config)
-                last_activity = time.time()
-            except queue.Empty:
-                if idle_timeout > 0 and time.time() - last_activity > idle_timeout:
-                    print(f"💤 {idle_timeout // 60}分間スクショがなかったため終了します。")
-                    break
-            time.sleep(0.5)
-    except KeyboardInterrupt:
-        print("\n監視を終了しました。")
+    state = {"last_activity": time.time(), "processing": False}
 
+    def check_queue():
+        """0.5秒おきにキューを確認する。イベントループから呼ばれる。"""
+        # ダイアログ表示中はネストしたイベントループが回っており、ここが再入する。
+        # ガードが無いと2件目の処理が入れ子で走り、ダイアログが二重に開く。
+        if state["processing"]:
+            return
+
+        try:
+            filepath = file_queue.get_nowait()
+        except queue.Empty:
+            if idle_timeout > 0 and time.time() - state["last_activity"] > idle_timeout:
+                print(f"💤 {idle_timeout // 60}分間スクショがなかったため終了します。")
+                stop_event_loop()
+            return
+
+        state["processing"] = True
+        try:
+            process_screenshot(filepath, config)
+        finally:
+            state["processing"] = False
+            state["last_activity"] = time.time()
+
+    # 待機中もイベントを処理し続ける必要があるため、Qtのイベントループを本体にする
+    run_event_loop(check_queue, interval_ms=500)
+
+    print("\n監視を終了しました。")
     observer.stop()
     observer.join()

--- a/main.py
+++ b/main.py
@@ -22,8 +22,9 @@ from popup_ui import run_event_loop, show_rename_dialog, stop_event_loop
 file_queue = queue.Queue()
 processed_files = set()  # 重複処理防止用のセット
 
-# launchdのWatchPathsで起動された直後に拾う、既存ファイルの新しさの上限（秒）
-STARTUP_SCAN_MAX_AGE_SECONDS = 60
+# 「撮りたて」と見なす更新時刻の上限（秒）。
+# launchdのWatchPathsで起動された直後のスキャンと、監視中のイベント判定の両方で使う。
+RECENT_FILE_MAX_AGE_SECONDS = 60
 
 
 class ScreenshotHandler(FileSystemEventHandler):
@@ -35,12 +36,20 @@ class ScreenshotHandler(FileSystemEventHandler):
         # 隠しファイル除外 ＆ PNG画像のみ対象
         if not path.lower().endswith('.png') or filename.startswith('.'):
             return
-        
+
+        if not os.path.exists(path) or path in processed_files:
+            return
+
+        # 手動リネーム（--rename）で既存ファイルの名前を変えると on_moved が発火するが、
+        # 撮りたてのスクショと違い更新時刻は古いままなので、それを手掛かりに除外する。
+        # 手動モードは別プロセスのため processed_files では共有できない。
+        if not is_recent(path):
+            return
+
         # 即座にキューへ入れる（イベントスレッドをブロックしない）
-        if os.path.exists(path) and path not in processed_files:
-            print(f"\n📸 新規スクリーンショットを検知: {path}")
-            processed_files.add(path)
-            file_queue.put(path)
+        print(f"\n📸 新規スクリーンショットを検知: {path}")
+        processed_files.add(path)
+        file_queue.put(path)
 
     # macOSのスクショ特有の挙動（一時ファイルからのリネーム発生）を検知
     def on_moved(self, event):
@@ -53,18 +62,23 @@ class ScreenshotHandler(FileSystemEventHandler):
             self.enqueue(event.src_path)
 
 
+def is_recent(path):
+    """撮りたてのファイルか（更新時刻が十分に新しいか）。"""
+    try:
+        return time.time() - os.path.getmtime(path) <= RECENT_FILE_MAX_AGE_SECONDS
+    except OSError:
+        return False
+
+
 def enqueue_recent_files(handler, watch_dir):
     """launchdのWatchPathsで起動された場合、起動のきっかけとなったスクショは
     watchdogのイベントに乗らないため、起動直後に直接キューへ入れる。"""
     if not os.path.isdir(watch_dir):
         return
 
-    now = time.time()
     for filename in os.listdir(watch_dir):
         path = os.path.join(watch_dir, filename)
-        if not os.path.isfile(path):
-            continue
-        if now - os.path.getmtime(path) <= STARTUP_SCAN_MAX_AGE_SECONDS:
+        if os.path.isfile(path):
             handler.enqueue(path)
 
 

--- a/ocr_engine.py
+++ b/ocr_engine.py
@@ -1,5 +1,6 @@
 import os
 import objc
+import AppKit
 import Foundation
 import Vision
 import Quartz
@@ -69,6 +70,44 @@ def _first_pdf_page(filepath: str):
     if document is None or document.pageCount() <= PDF_PAGE_INDEX:
         return None
     return document.pageAt_(PDF_PAGE_INDEX)
+
+
+def render_pdf_preview(filepath: str, max_pixels: int = 2000):
+    """PDFの先頭ページをPNGのバイト列にする。プレビュー表示用。
+
+    QPixmap はPDFを読めないため、PDFの扱いを知っているこのモジュールで
+    画像に変換して渡す（描画処理を二重に持たないため）。
+    """
+    with objc.autorelease_pool():
+        page = _first_pdf_page(filepath)
+        if page is None:
+            return None
+
+        bounds = page.boundsForBox_(Quartz.kPDFDisplayBoxMediaBox)
+        width, height = bounds.size.width, bounds.size.height
+        if width < 1 or height < 1:
+            return None
+
+        # 長辺を max_pixels に合わせる（拡大はしない）
+        scale = min(max_pixels / max(width, height), 1.0) or 1.0
+        size = Foundation.NSMakeSize(width * scale, height * scale)
+
+        image = page.thumbnailOfSize_forBox_(size, Quartz.kPDFDisplayBoxMediaBox)
+        if image is None:
+            return None
+
+        data = image.TIFFRepresentation()
+        if data is None:
+            return None
+
+        rep = AppKit.NSBitmapImageRep.imageRepWithData_(data)
+        if rep is None:
+            return None
+
+        png = rep.representationUsingType_properties_(
+            AppKit.NSBitmapImageFileTypePNG, {}
+        )
+        return bytes(png) if png is not None else None
 
 
 def _render_pdf_page(page):

--- a/ocr_engine.py
+++ b/ocr_engine.py
@@ -69,7 +69,7 @@ def _first_pdf_page(filepath: str):
     document = Quartz.PDFDocument.alloc().initWithURL_(url)
     if document is None or document.pageCount() <= PDF_PAGE_INDEX:
         return None
-    return document.pageAt_(PDF_PAGE_INDEX)
+    return document.pageAtIndex_(PDF_PAGE_INDEX)
 
 
 def render_pdf_preview(filepath: str, max_pixels: int = 2000):

--- a/ocr_engine.py
+++ b/ocr_engine.py
@@ -124,10 +124,10 @@ def _render_pdf_page(page):
     if image is None:
         return None
 
-    # CGImageForProposedRect: の第1引数は in/out のため、PyObjCでは
-    # (CGImage, rect) のタプルで返ることがある
-    result = image.CGImageForProposedRect_context_hints_(None, None, None)
-    return result[0] if isinstance(result, tuple) else result
+    # CGImageForProposedRect: の第1引数は in/out の NSRect* のため、
+    # PyObjCは (CGImage, rect) のタプルで返す
+    cg_image, _ = image.CGImageForProposedRect_context_hints_(None, None, None)
+    return cg_image
 
 
 def _recognize(handler) -> str:

--- a/ocr_engine.py
+++ b/ocr_engine.py
@@ -4,33 +4,111 @@ import Foundation
 import Vision
 import Quartz
 
-def extract_text(image_path: str) -> str:
-    if not os.path.exists(image_path):
+# 対応する画像形式。Vision はいずれもそのまま読める
+IMAGE_EXTENSIONS = (".png", ".jpg", ".jpeg", ".heic")
+PDF_EXTENSION = ".pdf"
+
+SUPPORTED_EXTENSIONS = IMAGE_EXTENSIONS + (PDF_EXTENSION,)
+
+# ファイル名を決めるには先頭ページだけあれば足りる
+PDF_PAGE_INDEX = 0
+# PDFを画像化する際の拡大率。OCR精度のため実寸より大きく描画する
+PDF_RENDER_SCALE = 2.0
+
+
+def is_supported(filepath: str) -> bool:
+    return filepath.lower().endswith(SUPPORTED_EXTENSIONS)
+
+
+def extract_text(filepath: str) -> str:
+    """画像またはPDFからテキストを取り出す。"""
+    if not os.path.exists(filepath):
         return ""
+
+    if filepath.lower().endswith(PDF_EXTENSION):
+        return _extract_pdf_text(filepath)
 
     # このスクリプトにはCocoaのイベントループが無く、通常のアプリのように
     # オートリリースプールが自動で drain されない。プールで明示的に囲むことで、
     # NSURL/VNImageRequestHandlerが掴んだファイルハンドルを含む一時オブジェクトを
     # この関数を抜けた時点で確実に解放する。
     with objc.autorelease_pool():
-        url = Foundation.NSURL.fileURLWithPath_(image_path)
+        url = Foundation.NSURL.fileURLWithPath_(filepath)
         handler = Vision.VNImageRequestHandler.alloc().initWithURL_options_(url, None)
-        request = Vision.VNRecognizeTextRequest.alloc().init()
-        request.setRecognitionLevel_(Vision.VNRequestTextRecognitionLevelAccurate)
-        request.setRecognitionLanguages_(["ja-JP", "en-US"])
+        return _recognize(handler)
 
-        success, error = handler.performRequests_error_([request], None)
-        if not success:
+
+def _extract_pdf_text(filepath: str) -> str:
+    """PDFはまず埋め込みテキストを試し、無ければ先頭ページを画像化してOCRする。
+
+    領収書や決算資料の大半はテキスト層を持つため、OCRより速く正確に取れる。
+    テキスト層が無いスキャンPDFのみレンダリングに回す。
+    """
+    with objc.autorelease_pool():
+        page = _first_pdf_page(filepath)
+        if page is None:
             return ""
 
-        results = request.results()
-        if not results:
+        text = page.string()
+        if text and text.strip():
+            return text.strip()
+
+        cg_image = _render_pdf_page(page)
+        if cg_image is None:
             return ""
 
-        extracted_text = []
-        for observation in results:
-            candidate = observation.topCandidates_(1).firstObject()
-            if candidate:
-                extracted_text.append(candidate.string())
+        handler = Vision.VNImageRequestHandler.alloc().initWithCGImage_options_(
+            cg_image, None
+        )
+        return _recognize(handler)
 
-        return "\n".join(extracted_text)
+
+def _first_pdf_page(filepath: str):
+    url = Foundation.NSURL.fileURLWithPath_(filepath)
+    document = Quartz.PDFDocument.alloc().initWithURL_(url)
+    if document is None or document.pageCount() <= PDF_PAGE_INDEX:
+        return None
+    return document.pageAt_(PDF_PAGE_INDEX)
+
+
+def _render_pdf_page(page):
+    """PDFのページをCGImageに描画する。Visionは画像しか受け取れないため。"""
+    bounds = page.boundsForBox_(Quartz.kPDFDisplayBoxMediaBox)
+    size = Foundation.NSMakeSize(
+        bounds.size.width * PDF_RENDER_SCALE,
+        bounds.size.height * PDF_RENDER_SCALE,
+    )
+    if size.width < 1 or size.height < 1:
+        return None
+
+    image = page.thumbnailOfSize_forBox_(size, Quartz.kPDFDisplayBoxMediaBox)
+    if image is None:
+        return None
+
+    # CGImageForProposedRect: の第1引数は in/out のため、PyObjCでは
+    # (CGImage, rect) のタプルで返ることがある
+    result = image.CGImageForProposedRect_context_hints_(None, None, None)
+    return result[0] if isinstance(result, tuple) else result
+
+
+def _recognize(handler) -> str:
+    """VNImageRequestHandler に文字認識をかけ、結果を改行区切りで返す。"""
+    request = Vision.VNRecognizeTextRequest.alloc().init()
+    request.setRecognitionLevel_(Vision.VNRequestTextRecognitionLevelAccurate)
+    request.setRecognitionLanguages_(["ja-JP", "en-US"])
+
+    success, error = handler.performRequests_error_([request], None)
+    if not success:
+        return ""
+
+    results = request.results()
+    if not results:
+        return ""
+
+    extracted_text = []
+    for observation in results:
+        candidate = observation.topCandidates_(1).firstObject()
+        if candidate:
+            extracted_text.append(candidate.string())
+
+    return "\n".join(extracted_text)

--- a/popup_ui.py
+++ b/popup_ui.py
@@ -8,9 +8,9 @@ from AppKit import (
 )
 from PyQt6.QtWidgets import (
     QApplication, QDialog, QVBoxLayout, QLabel,
-    QHBoxLayout, QFrame, QLineEdit
+    QHBoxLayout, QFrame, QLineEdit, QWidget
 )
-from PyQt6.QtCore import QSettings, QSize, QTimer, Qt
+from PyQt6.QtCore import QEvent, QSettings, QSize, QTimer, Qt
 from PyQt6.QtGui import QFont, QFontMetrics, QPixmap
 
 from ocr_engine import render_pdf_preview
@@ -47,9 +47,9 @@ class PreviewPane(QLabel):
 
         self.setAlignment(Qt.AlignmentFlag.AlignCenter)
         self.setMinimumHeight(160)
-        self.setStyleSheet(
-            "background-color: #000000; border: 1px solid #3A3A3C; border-radius: 6px;"
-        )
+        # 黒背景・枠を置くと、画像とウィンドウの比率が違うときに黒帯として目立つ。
+        # 背景を敷かず、余った部分はダイアログの地の色に馴染ませる。
+        self.setStyleSheet("background: transparent; border: none;")
 
         if self.source is None:
             # プレビューが出せなくてもリネーム操作は続行できるようにする
@@ -97,6 +97,12 @@ class PreviewPane(QLabel):
         )
         scaled.setDevicePixelRatio(ratio)
         self.setPixmap(scaled)
+
+    def aspect_ratio(self):
+        """元画像の縦横比。プレビューが無ければ None。"""
+        if self.source is None or self.source.height() == 0:
+            return None
+        return self.source.width() / self.source.height()
 
     def resizeEvent(self, event):
         self._rescale()
@@ -150,25 +156,40 @@ class RenameDialog(QDialog):
         self.filepath = filepath
         # timeout_seconds が None のときはタイマーを動かさない（手動モード）
         self.time_left = timeout_seconds
+        # 候補を選び始めたらカウントダウンをこの秒数に戻す
+        self.timeout_seconds = timeout_seconds
         self.progress = progress
         self.selected_name = None
         self.aborted = False
+        self.editing = False
         self.cards = []
         self.current_index = 0
         self.settings = QSettings(SETTINGS_ORG, SETTINGS_APP)
 
         self.init_ui()
 
-    def _initial_size(self):
-        """前回のサイズがあればそれを使う。無ければ既定値。画面をはみ出さないよう上限を設ける。"""
-        width = self.settings.value("width", DEFAULT_WIDTH, type=int)
-        height = self.settings.value("height", DEFAULT_HEIGHT, type=int)
+    def _initial_size(self, aspect_ratio=None):
+        """前回のサイズがあればそれを使う。無ければ画像の縦横比に合わせる。
+
+        既定サイズを固定にすると画像との比率が合わず、上下または左右に帯ができる。
+        初回は画像の比率からウィンドウの大きさを決めて、帯が出ないようにする。
+        """
+        width = self.settings.value("width", 0, type=int)
+        height = self.settings.value("height", 0, type=int)
+
+        if width <= 0 or height <= 0:
+            width = DEFAULT_WIDTH
+            height = int(width / aspect_ratio) if aspect_ratio else DEFAULT_HEIGHT
 
         screen = QApplication.primaryScreen()
         if screen:
             available = screen.availableGeometry()
-            width = min(width, int(available.width() * SCREEN_RATIO))
-            height = min(height, int(available.height() * SCREEN_RATIO))
+            max_width = int(available.width() * SCREEN_RATIO)
+            max_height = int(available.height() * SCREEN_RATIO)
+            # 画面に収めるときも比率を保つ
+            scale = min(max_width / width, max_height / height, 1.0)
+            width = int(width * scale)
+            height = int(height * scale)
 
         return QSize(max(width, 1), max(height, 1))
 
@@ -183,17 +204,53 @@ class RenameDialog(QDialog):
         self.setStyleSheet("background-color: #1E1E1E; color: #FFFFFF;")
         self.setWindowFlags(Qt.WindowType.WindowStaysOnTopHint)
         self.setSizeGripEnabled(True)
-        self.resize(self._initial_size())
 
+        # --- プレビュー（全面） ---
+        # 画像を画面いっぱいに敷き、操作パネルはその上に重ねる
+        self.preview = PreviewPane(self.filepath)
         layout = QVBoxLayout(self)
-        layout.setContentsMargins(20, 18, 20, 16)
-        layout.setSpacing(10)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self.preview)
+
+        self.resize(self._initial_size(self.preview.aspect_ratio()))
+
+        self._build_overlay()
+
+        # 初期表示・フォーカス設定
+        # 最初はカーソルを立てず、候補を選べる状態にする。
+        # 編集したくなったら Tab か編集欄のクリックでカーソルが入る。
+        self.update_card_styles()
+        self.setFocus()
+
+        # タイマー
+        self.timer = QTimer(self)
+        self.timer.timeout.connect(self.update_timer)
+        if self._has_timeout():
+            self.timer.start(1000)
+
+    def _build_overlay(self):
+        """画像の上に重ねる操作パネル。レイアウトには載せず、自前で位置を決める。"""
+        self.overlay = QWidget(self)
+        self.overlay.setAttribute(Qt.WidgetAttribute.WA_StyledBackground, True)
+        self.overlay.setStyleSheet("""
+            QWidget#overlay {
+                background-color: rgba(24, 24, 26, 0.82);
+                border: 1px solid rgba(255, 255, 255, 0.10);
+                border-radius: 14px;
+            }
+        """)
+        self.overlay.setObjectName("overlay")
+
+        layout = QVBoxLayout(self.overlay)
+        layout.setContentsMargins(18, 14, 18, 14)
+        layout.setSpacing(8)
 
         # --- ヘッダー ---
         header_layout = QHBoxLayout()
 
         title_label = QLabel("ファイル名を選択")
-        title_label.setFont(QFont("SF Pro Text", 13, QFont.Weight.Bold))
+        title_label.setFont(QFont("SF Pro Text", 12, QFont.Weight.Bold))
+        title_label.setStyleSheet("background: transparent;")
         header_layout.addWidget(title_label)
         header_layout.addStretch()
 
@@ -202,26 +259,16 @@ class RenameDialog(QDialog):
             done, total = self.progress
             progress_label = QLabel(f"{done} / {total}")
             progress_label.setFont(QFont("SF Pro Text", 11))
-            progress_label.setStyleSheet("color: #8E8E93;")
+            progress_label.setStyleSheet("color: #8E8E93; background: transparent;")
             header_layout.addWidget(progress_label)
 
         layout.addLayout(header_layout)
 
         self.timer_label = QLabel()
         self.timer_label.setFont(QFont("SF Pro Text", 10))
-        self.timer_label.setStyleSheet("color: #0A84FF;")
-        if self._has_timeout():
-            self.timer_label.setText(
-                f"選択されない場合、{self.time_left}秒後に第1候補で自動保存します"
-            )
-        else:
-            self.timer_label.setText("名前を選ぶか、直接書き換えて Enter で確定します")
+        self.timer_label.setStyleSheet("color: #0A84FF; background: transparent;")
+        self.timer_label.setText(self._status_text())
         layout.addWidget(self.timer_label)
-
-        # --- プレビュー ---
-        # 余った領域は全てプレビューに割り当てる。ウィンドウを広げた分だけ大きく見える
-        self.preview = PreviewPane(self.filepath)
-        layout.addWidget(self.preview, stretch=1)
 
         # --- 候補リスト ---
         for cand in self.candidates:
@@ -230,21 +277,25 @@ class RenameDialog(QDialog):
             self.cards.append(card)
 
         # --- 編集欄 ---
-        # 候補を選ぶとここに入る。そのまま書き換えて確定できる
+        # 候補を選ぶとここに入る。Tab またはクリックでカーソルが入り、書き換えられる
         self.name_edit = QLineEdit()
         self.name_edit.setFont(QFont("SF Mono", 11))
-        self.name_edit.setFixedHeight(38)
+        self.name_edit.setFixedHeight(36)
+        # Tabキーは自前で処理する。勝手にフォーカスが移らないようクリックのみ許可する
+        self.name_edit.setFocusPolicy(Qt.FocusPolicy.ClickFocus)
         self.name_edit.setStyleSheet("""
             QLineEdit {
-                background-color: #2C2C2E;
-                border: 1px solid #3A3A3C;
-                border-radius: 6px;
+                background-color: rgba(60, 60, 64, 0.85);
+                border: 1px solid rgba(255, 255, 255, 0.12);
+                border-radius: 8px;
                 padding: 0 10px;
                 color: #FFFFFF;
             }
             QLineEdit:focus { border: 2px solid #0A84FF; }
         """)
         self.name_edit.returnPressed.connect(self.confirm_edited_name)
+        # 編集欄にカーソルが入ったらタイマーを止めるため、フォーカスを監視する
+        self.name_edit.installEventFilter(self)
         if self.candidates:
             self.name_edit.setText(self.candidates[0])
         layout.addWidget(self.name_edit)
@@ -257,68 +308,120 @@ class RenameDialog(QDialog):
             abort_btn = QLabel("すべて中止")
             abort_btn.setFont(QFont("SF Pro Text", 10))
             abort_btn.setCursor(Qt.CursorShape.PointingHandCursor)
-            abort_btn.setStyleSheet("color: #FF9F0A; margin-right: 16px;")
+            abort_btn.setStyleSheet("color: #FF9F0A; margin-right: 16px; background: transparent;")
             abort_btn.mousePressEvent = lambda e: self.on_abort()
             footer_layout.addWidget(abort_btn)
 
         cancel_btn = QLabel("スキップ（変更しない）" if self.progress else "キャンセル（保存しない）")
         cancel_btn.setFont(QFont("SF Pro Text", 10))
         cancel_btn.setCursor(Qt.CursorShape.PointingHandCursor)
-        cancel_btn.setStyleSheet("color: #FF453A;")
+        cancel_btn.setStyleSheet("color: #FF453A; background: transparent;")
         cancel_btn.mousePressEvent = lambda e: self.on_select(None)
         footer_layout.addWidget(cancel_btn)
 
         layout.addLayout(footer_layout)
 
-        # 初期表示・フォーカス設定
-        # 矢印キーは dialog 側で拾うため、フォーカスは常に編集欄に置く
-        self.update_card_styles()
-        self.name_edit.setFocus()
+    def _position_overlay(self):
+        """操作パネルをウィンドウ下部に配置する。"""
+        if not hasattr(self, "overlay"):
+            return
+        margin = 20
+        width = max(self.width() - margin * 2, 200)
+        height = self.overlay.sizeHint().height()
+        self.overlay.setGeometry(margin, self.height() - height - margin, width, height)
+        self.overlay.raise_()
 
-        # タイマー
-        self.timer = QTimer(self)
-        self.timer.timeout.connect(self.update_timer)
-        if self._has_timeout():
-            self.timer.start(1000)
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        self._position_overlay()
 
     def _has_timeout(self):
         return bool(self.time_left)
+
+    def _status_text(self):
+        if self.editing:
+            return "自動保存を止めました。Enter で確定します"
+        if self._has_timeout():
+            return f"選択されない場合、{self.time_left}秒後に第1候補で自動保存します"
+        return "↑↓ で候補を選び、Tab で書き換え、Enter で確定します"
 
     def update_card_styles(self):
         """選択状態に合わせてカードとラベルのスタイルを一括変更"""
         for i, card in enumerate(self.cards):
             is_active = (i == self.current_index)
             
-            border = "2px solid #0A84FF" if is_active else "1px solid #3A3A3C"
-            text_color = "#64D2FF" if is_active else "#FFFFFF"
+            border = (
+                "2px solid #0A84FF" if is_active
+                else "1px solid rgba(255, 255, 255, 0.12)"
+            )
+            background = (
+                "rgba(10, 132, 255, 0.22)" if is_active
+                else "rgba(70, 70, 74, 0.55)"
+            )
+            text_color = "#7FD3FF" if is_active else "#FFFFFF"
 
             card.setStyleSheet(f"""
                 QFrame {{
-                    background-color: #2C2C2E;
+                    background-color: {background};
                     border: {border};
-                    border-radius: 6px;
+                    border-radius: 8px;
                 }}
                 QFrame:hover {{
-                    background-color: #3A3A3C;
+                    background-color: rgba(100, 100, 105, 0.65);
                 }}
             """)
             card.label.setStyleSheet(f"color: {text_color}; border: none; background: transparent;")
 
     def select_candidate(self, index):
-        """候補を選び、編集欄の中身を差し替える。"""
+        """候補を選び、編集欄の中身を差し替える。カーソルは立てない。"""
         if not (0 <= index < len(self.candidates)):
             return
         self.current_index = index
         self.update_card_styles()
         self.name_edit.setText(self.candidates[index])
+        # 候補を見比べている最中に自動保存されないよう、カウントダウンを戻す
+        self.extend_timeout()
+
+    def extend_timeout(self):
+        """操作があったらカウントダウンを最初からやり直す。"""
+        if self.editing or not self._has_timeout():
+            return
+        self.time_left = self.timeout_seconds
+        self.timer_label.setText(self._status_text())
+
+    def enter_edit_mode(self):
+        """編集欄にカーソルを入れる。自分で書く以上、自動保存は止める。"""
+        if self.editing:
+            return
+        self.editing = True
+        self.timer.stop()
+        self.timer_label.setText(self._status_text())
         self.name_edit.setFocus()
+        self.name_edit.setCursorPosition(len(self.name_edit.text()))
+
+    def eventFilter(self, obj, event):
+        # 編集欄をクリックされた場合もタイマーを止める
+        if obj is self.name_edit and event.type() == QEvent.Type.FocusIn:
+            self.enter_edit_mode()
+        return super().eventFilter(obj, event)
 
     def keyPressEvent(self, event):
         key = event.key()
 
+        # 編集中は矢印キーを文字カーソルの移動として扱う（候補は切り替えない）
+        if self.editing and key in (Qt.Key.Key_Down, Qt.Key.Key_Up):
+            super().keyPressEvent(event)
+            return
+
         if key in (Qt.Key.Key_Down, Qt.Key.Key_Up):
             delta = 1 if key == Qt.Key.Key_Down else -1
             self.select_candidate(self.current_index + delta)
+
+        elif key == Qt.Key.Key_Tab:
+            self.enter_edit_mode()
+
+        elif key in (Qt.Key.Key_Return, Qt.Key.Key_Enter):
+            self.confirm_edited_name()
 
         elif key == Qt.Key.Key_Escape:
             self.on_select(None)
@@ -332,9 +435,10 @@ class RenameDialog(QDialog):
     def update_timer(self):
         self.time_left -= 1
         if self.time_left > 0:
-            self.timer_label.setText(f"選択されない場合、{self.time_left}秒後に第1候補で自動保存します")
+            self.timer_label.setText(self._status_text())
         else:
-            self.on_select(self.candidates[0] if self.candidates else None)
+            # 放置された場合は従来通り、現在選んでいる候補で自動保存する
+            self.on_select(self.name_edit.text() or None)
 
     def on_select(self, name):
         self.timer.stop()

--- a/popup_ui.py
+++ b/popup_ui.py
@@ -4,16 +4,22 @@ from PyQt6.QtWidgets import (
     QApplication, QDialog, QVBoxLayout, QLabel,
     QHBoxLayout, QFrame
 )
-from PyQt6.QtCore import QTimer, Qt
+from PyQt6.QtCore import QSize, QTimer, Qt
 from PyQt6.QtGui import QFont, QFontMetrics
+
+# ダイアログの初期サイズ。画面が小さい場合は SCREEN_RATIO まで縮める
+DEFAULT_WIDTH = 1280
+DEFAULT_HEIGHT = 760
+SCREEN_RATIO = 0.9
+
 
 class CandidateCard(QFrame):
     """テキストが100%垂直中央に揃うカード型選択肢"""
-    def __init__(self, text, cand, parent_dialog):
+    def __init__(self, cand, parent_dialog):
         super().__init__()
         self.cand = cand
         self.parent_dialog = parent_dialog
-        
+
         self.setFixedHeight(46)
         self.setCursor(Qt.CursorShape.PointingHandCursor)
         self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
@@ -21,11 +27,26 @@ class CandidateCard(QFrame):
         layout = QHBoxLayout(self)
         layout.setContentsMargins(12, 0, 12, 0)
 
-        self.label = QLabel(f" {text}")
+        self.label = QLabel()
         self.label.setFont(QFont("SF Mono", 10))
         # 確実に左寄せ＆垂直中央揃え
         self.label.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter)
         layout.addWidget(self.label)
+
+        self._update_elided_text()
+
+    def _update_elided_text(self):
+        """幅に合わせて省略位置を計算し直す。ウィンドウを広げれば全体が見える。"""
+        metrics = QFontMetrics(self.label.font())
+        available = max(self.width() - 40, 0)
+        text = f" {metrics.elidedText(self.cand, Qt.TextElideMode.ElideLeft, available)}"
+        # 同じ文字列を再設定するとレイアウトが再帰的に走るため、変化時のみ更新する
+        if text != self.label.text():
+            self.label.setText(text)
+
+    def resizeEvent(self, event):
+        self._update_elided_text()
+        super().resizeEvent(event)
 
     def mousePressEvent(self, event):
         if event.button() == Qt.MouseButton.LeftButton:
@@ -43,11 +64,22 @@ class RenameDialog(QDialog):
 
         self.init_ui()
 
+    def _initial_size(self):
+        """初期サイズ。画面をはみ出さないよう上限を設ける。"""
+        width, height = DEFAULT_WIDTH, DEFAULT_HEIGHT
+        screen = QApplication.primaryScreen()
+        if screen:
+            available = screen.availableGeometry()
+            width = min(width, int(available.width() * SCREEN_RATIO))
+            height = min(height, int(available.height() * SCREEN_RATIO))
+        return QSize(width, height)
+
     def init_ui(self):
         self.setWindowTitle("Screenshot Renamer")
-        self.setFixedSize(620, 310)
         self.setStyleSheet("background-color: #1E1E1E; color: #FFFFFF;")
         self.setWindowFlags(Qt.WindowType.WindowStaysOnTopHint)
+        self.setSizeGripEnabled(True)
+        self.resize(self._initial_size())
 
         layout = QVBoxLayout(self)
         layout.setContentsMargins(20, 18, 20, 16)
@@ -64,12 +96,8 @@ class RenameDialog(QDialog):
         layout.addWidget(self.timer_label)
 
         # --- 候補リスト ---
-        btn_font = QFont("SF Mono", 10)
-        font_metrics = QFontMetrics(btn_font)
-
         for cand in self.candidates:
-            display_text = font_metrics.elidedText(cand, Qt.TextElideMode.ElideLeft, 540)
-            card = CandidateCard(display_text, cand, self)
+            card = CandidateCard(cand, self)
             layout.addWidget(card)
             self.cards.append(card)
 

--- a/popup_ui.py
+++ b/popup_ui.py
@@ -118,7 +118,9 @@ class CandidateCard(QFrame):
 
         self.setFixedHeight(46)
         self.setCursor(Qt.CursorShape.PointingHandCursor)
-        self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
+        # 選択状態は current_index で管理する。カードにフォーカスを持たせると
+        # Tab がカード間の移動に使われ、編集欄へ移せなくなる
+        self.setFocusPolicy(Qt.FocusPolicy.NoFocus)
 
         layout = QHBoxLayout(self)
         layout.setContentsMargins(12, 0, 12, 0)
@@ -204,6 +206,8 @@ class RenameDialog(QDialog):
         self.setStyleSheet("background-color: #1E1E1E; color: #FFFFFF;")
         self.setWindowFlags(Qt.WindowType.WindowStaysOnTopHint)
         self.setSizeGripEnabled(True)
+        # キー操作はダイアログ側で受ける
+        self.setFocusPolicy(Qt.FocusPolicy.StrongFocus)
 
         # --- プレビュー（全面） ---
         # 画像を画面いっぱいに敷き、操作パネルはその上に重ねる
@@ -221,6 +225,7 @@ class RenameDialog(QDialog):
         # 編集したくなったら Tab か編集欄のクリックでカーソルが入る。
         self.update_card_styles()
         self.setFocus()
+        self._position_overlay()
 
         # タイマー
         self.timer = QTimer(self)

--- a/popup_ui.py
+++ b/popup_ui.py
@@ -10,19 +10,17 @@ from PyQt6.QtWidgets import (
     QApplication, QDialog, QVBoxLayout, QLabel,
     QHBoxLayout, QFrame, QLineEdit, QWidget
 )
-from PyQt6.QtCore import QEvent, QSettings, QSize, QTimer, Qt
+from PyQt6.QtCore import QEvent, QSize, QTimer, Qt
 from PyQt6.QtGui import QFont, QFontMetrics, QPixmap
 
 from ocr_engine import render_pdf_preview
 
-# ダイアログの初期サイズ。画面が小さい場合は SCREEN_RATIO まで縮める
+# ウィンドウの基準サイズ。実際の幅・高さは常にプレビュー画像の縦横比から決め直す
+# （Preview.appのように、開くたびに画像に合わせて余白なく収める）。
+# 画像が無い場合のみこの値を使う。画面が小さい場合は SCREEN_RATIO まで縮める
 DEFAULT_WIDTH = 1280
 DEFAULT_HEIGHT = 760
 SCREEN_RATIO = 0.9
-
-# ウィンドウサイズの保存先。利用者が編集する設定ではないため config.yaml には置かない
-SETTINGS_ORG = "screenshot_renamer"
-SETTINGS_APP = "RenameDialog"
 
 
 def sanitize_filename(name):
@@ -166,22 +164,17 @@ class RenameDialog(QDialog):
         self.editing = False
         self.cards = []
         self.current_index = 0
-        self.settings = QSettings(SETTINGS_ORG, SETTINGS_APP)
 
         self.init_ui()
 
     def _initial_size(self, aspect_ratio=None):
-        """前回のサイズがあればそれを使う。無ければ画像の縦横比に合わせる。
+        """画像の縦横比からウィンドウの大きさを決める。
 
         既定サイズを固定にすると画像との比率が合わず、上下または左右に帯ができる。
-        初回は画像の比率からウィンドウの大きさを決めて、帯が出ないようにする。
+        開くたびに画像の比率からウィンドウを決め直すことで、帯が出ないようにする。
         """
-        width = self.settings.value("width", 0, type=int)
-        height = self.settings.value("height", 0, type=int)
-
-        if width <= 0 or height <= 0:
-            width = DEFAULT_WIDTH
-            height = int(width / aspect_ratio) if aspect_ratio else DEFAULT_HEIGHT
+        width = DEFAULT_WIDTH
+        height = int(width / aspect_ratio) if aspect_ratio else DEFAULT_HEIGHT
 
         screen = QApplication.primaryScreen()
         if screen:
@@ -194,12 +187,6 @@ class RenameDialog(QDialog):
             height = int(height * scale)
 
         return QSize(max(width, 1), max(height, 1))
-
-    def done(self, result):
-        """閉じ方（選択・キャンセル・タイムアウト）に関わらず最後のサイズを覚える"""
-        self.settings.setValue("width", self.width())
-        self.settings.setValue("height", self.height())
-        super().done(result)
 
     def init_ui(self):
         self.setWindowTitle("Screenshot Renamer")

--- a/popup_ui.py
+++ b/popup_ui.py
@@ -13,6 +13,8 @@ from PyQt6.QtWidgets import (
 from PyQt6.QtCore import QSettings, QSize, QTimer, Qt
 from PyQt6.QtGui import QFont, QFontMetrics, QPixmap
 
+from ocr_engine import render_pdf_preview
+
 # ダイアログの初期サイズ。画面が小さい場合は SCREEN_RATIO まで縮める
 DEFAULT_WIDTH = 1280
 DEFAULT_HEIGHT = 760
@@ -58,8 +60,25 @@ class PreviewPane(QLabel):
     def _load(self, filepath):
         if not filepath or not os.path.exists(filepath):
             return None
+
+        if filepath.lower().endswith(".pdf"):
+            return self._load_pdf(filepath)
+
         pixmap = QPixmap(filepath)
         return None if pixmap.isNull() else pixmap
+
+    def _load_pdf(self, filepath):
+        """QPixmapはPDFを読めないため、画像に変換してもらってから読み込む。"""
+        try:
+            data = render_pdf_preview(filepath)
+        except Exception:
+            return None
+
+        if not data:
+            return None
+
+        pixmap = QPixmap()
+        return pixmap if pixmap.loadFromData(data) else None
 
     def _rescale(self):
         if self.source is None:

--- a/popup_ui.py
+++ b/popup_ui.py
@@ -1,10 +1,14 @@
 import os
 import signal
 import sys
-from AppKit import NSApplication, NSApplicationActivationPolicyAccessory
+from AppKit import (
+    NSApplication,
+    NSApplicationActivationPolicyAccessory,
+    NSApplicationActivationPolicyRegular,
+)
 from PyQt6.QtWidgets import (
     QApplication, QDialog, QVBoxLayout, QLabel,
-    QHBoxLayout, QFrame
+    QHBoxLayout, QFrame, QLineEdit
 )
 from PyQt6.QtCore import QSettings, QSize, QTimer, Qt
 from PyQt6.QtGui import QFont, QFontMetrics, QPixmap
@@ -17,6 +21,18 @@ SCREEN_RATIO = 0.9
 # ウィンドウサイズの保存先。利用者が編集する設定ではないため config.yaml には置かない
 SETTINGS_ORG = "screenshot_renamer"
 SETTINGS_APP = "RenameDialog"
+
+
+def sanitize_filename(name):
+    """入力された名前をファイル名として使える形に整える。使えなければ None。"""
+    if not name:
+        return None
+
+    # "/" はパス区切りとして解釈されるため使えない
+    cleaned = name.strip().replace("/", "_").replace("\0", "")
+    # 先頭がドットだと不可視ファイルになってしまう
+    cleaned = cleaned.lstrip(".").strip()
+    return cleaned or None
 
 
 class PreviewPane(QLabel):
@@ -109,12 +125,15 @@ class CandidateCard(QFrame):
 
 
 class RenameDialog(QDialog):
-    def __init__(self, candidates, filepath=None, timeout_seconds=10):
+    def __init__(self, candidates, filepath=None, timeout_seconds=10, progress=None):
         super().__init__()
         self.candidates = candidates
         self.filepath = filepath
+        # timeout_seconds が None のときはタイマーを動かさない（手動モード）
         self.time_left = timeout_seconds
+        self.progress = progress
         self.selected_name = None
+        self.aborted = False
         self.cards = []
         self.current_index = 0
         self.settings = QSettings(SETTINGS_ORG, SETTINGS_APP)
@@ -152,13 +171,32 @@ class RenameDialog(QDialog):
         layout.setSpacing(10)
 
         # --- ヘッダー ---
+        header_layout = QHBoxLayout()
+
         title_label = QLabel("ファイル名を選択")
         title_label.setFont(QFont("SF Pro Text", 13, QFont.Weight.Bold))
-        layout.addWidget(title_label)
+        header_layout.addWidget(title_label)
+        header_layout.addStretch()
 
-        self.timer_label = QLabel(f"選択されない場合、{self.time_left}秒後に第1候補で自動保存します")
+        if self.progress:
+            # 複数ファイルを順に処理しているときの「3 / 50」表示
+            done, total = self.progress
+            progress_label = QLabel(f"{done} / {total}")
+            progress_label.setFont(QFont("SF Pro Text", 11))
+            progress_label.setStyleSheet("color: #8E8E93;")
+            header_layout.addWidget(progress_label)
+
+        layout.addLayout(header_layout)
+
+        self.timer_label = QLabel()
         self.timer_label.setFont(QFont("SF Pro Text", 10))
         self.timer_label.setStyleSheet("color: #0A84FF;")
+        if self._has_timeout():
+            self.timer_label.setText(
+                f"選択されない場合、{self.time_left}秒後に第1候補で自動保存します"
+            )
+        else:
+            self.timer_label.setText("名前を選ぶか、直接書き換えて Enter で確定します")
         layout.addWidget(self.timer_label)
 
         # --- プレビュー ---
@@ -172,11 +210,39 @@ class RenameDialog(QDialog):
             layout.addWidget(card)
             self.cards.append(card)
 
+        # --- 編集欄 ---
+        # 候補を選ぶとここに入る。そのまま書き換えて確定できる
+        self.name_edit = QLineEdit()
+        self.name_edit.setFont(QFont("SF Mono", 11))
+        self.name_edit.setFixedHeight(38)
+        self.name_edit.setStyleSheet("""
+            QLineEdit {
+                background-color: #2C2C2E;
+                border: 1px solid #3A3A3C;
+                border-radius: 6px;
+                padding: 0 10px;
+                color: #FFFFFF;
+            }
+            QLineEdit:focus { border: 2px solid #0A84FF; }
+        """)
+        self.name_edit.returnPressed.connect(self.confirm_edited_name)
+        if self.candidates:
+            self.name_edit.setText(self.candidates[0])
+        layout.addWidget(self.name_edit)
+
         # --- フッター ---
         footer_layout = QHBoxLayout()
         footer_layout.addStretch()
 
-        cancel_btn = QLabel("キャンセル（保存しない）")
+        if self.progress:
+            abort_btn = QLabel("すべて中止")
+            abort_btn.setFont(QFont("SF Pro Text", 10))
+            abort_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+            abort_btn.setStyleSheet("color: #FF9F0A; margin-right: 16px;")
+            abort_btn.mousePressEvent = lambda e: self.on_abort()
+            footer_layout.addWidget(abort_btn)
+
+        cancel_btn = QLabel("スキップ（変更しない）" if self.progress else "キャンセル（保存しない）")
         cancel_btn.setFont(QFont("SF Pro Text", 10))
         cancel_btn.setCursor(Qt.CursorShape.PointingHandCursor)
         cancel_btn.setStyleSheet("color: #FF453A;")
@@ -186,14 +252,18 @@ class RenameDialog(QDialog):
         layout.addLayout(footer_layout)
 
         # 初期表示・フォーカス設定
+        # 矢印キーは dialog 側で拾うため、フォーカスは常に編集欄に置く
         self.update_card_styles()
-        if self.cards:
-            self.cards[0].setFocus()
+        self.name_edit.setFocus()
 
         # タイマー
         self.timer = QTimer(self)
         self.timer.timeout.connect(self.update_timer)
-        self.timer.start(1000)
+        if self._has_timeout():
+            self.timer.start(1000)
+
+    def _has_timeout(self):
+        return bool(self.time_left)
 
     def update_card_styles(self):
         """選択状態に合わせてカードとラベルのスタイルを一括変更"""
@@ -215,25 +285,30 @@ class RenameDialog(QDialog):
             """)
             card.label.setStyleSheet(f"color: {text_color}; border: none; background: transparent;")
 
+    def select_candidate(self, index):
+        """候補を選び、編集欄の中身を差し替える。"""
+        if not (0 <= index < len(self.candidates)):
+            return
+        self.current_index = index
+        self.update_card_styles()
+        self.name_edit.setText(self.candidates[index])
+        self.name_edit.setFocus()
+
     def keyPressEvent(self, event):
         key = event.key()
 
         if key in (Qt.Key.Key_Down, Qt.Key.Key_Up):
             delta = 1 if key == Qt.Key.Key_Down else -1
-            new_idx = self.current_index + delta
-            if 0 <= new_idx < len(self.cards):
-                self.current_index = new_idx
-                self.update_card_styles()
-                self.cards[self.current_index].setFocus()
-
-        elif key in (Qt.Key.Key_Return, Qt.Key.Key_Enter):
-            if 0 <= self.current_index < len(self.candidates):
-                self.on_select(self.candidates[self.current_index])
+            self.select_candidate(self.current_index + delta)
 
         elif key == Qt.Key.Key_Escape:
             self.on_select(None)
         else:
             super().keyPressEvent(event)
+
+    def confirm_edited_name(self):
+        """編集欄の内容で確定する。"""
+        self.on_select(self.name_edit.text())
 
     def update_timer(self):
         self.time_left -= 1
@@ -244,8 +319,16 @@ class RenameDialog(QDialog):
 
     def on_select(self, name):
         self.timer.stop()
-        self.selected_name = name
+        # 候補クリック・キー確定・タイムアウトのどの経路でも同じ整形を通す
+        self.selected_name = sanitize_filename(name)
         self.accept()
+
+    def on_abort(self):
+        """複数処理中に残り全てを中止する。"""
+        self.timer.stop()
+        self.aborted = True
+        self.selected_name = None
+        self.reject()
 
 
 # QApplicationをローカル変数だけで持つと関数を抜けた時点で破棄される。
@@ -254,18 +337,25 @@ class RenameDialog(QDialog):
 _app = None
 
 
-def _ensure_app():
-    """QApplicationを取得（無ければ生成）し、常駐ツールとしての体裁を整える。"""
+def _ensure_app(foreground=False):
+    """QApplicationを取得（無ければ生成）し、常駐ツールとしての体裁を整える。
+
+    foreground=True は手動モード用。利用者が自分で起動しているため、
+    通常のアプリとして前面に出るのが正しい。
+    """
     global _app
     app = QApplication.instance() or QApplication(sys.argv)
     _app = app
 
-    # QApplicationを生成するとプロセスが通常のGUIアプリ扱いになり、Dockアイコンと
-    # メニューバーを占有したまま常駐してしまう。メニューバー常駐アプリと同じ
-    # Accessory に変更し、Dockに居座らせない。
-    NSApplication.sharedApplication().setActivationPolicy_(
-        NSApplicationActivationPolicyAccessory
+    # 監視モードでは、QApplicationを生成するとプロセスが通常のGUIアプリ扱いになり、
+    # Dockアイコンとメニューバーを占有したまま常駐してしまう。メニューバー常駐アプリと
+    # 同じ Accessory に変更し、Dockに居座らせない。
+    policy = (
+        NSApplicationActivationPolicyRegular
+        if foreground
+        else NSApplicationActivationPolicyAccessory
     )
+    NSApplication.sharedApplication().setActivationPolicy_(policy)
 
     # これが無いと、リネームのダイアログを閉じた時点で「最後のウィンドウが閉じた」と
     # 判断され、常駐プロセスごと終了してしまう。
@@ -299,11 +389,16 @@ def stop_event_loop():
         app.quit()
 
 
-def show_rename_dialog(candidates, filepath=None, timeout_seconds=10):
-    app = _ensure_app()
+def show_rename_dialog(candidates, filepath=None, timeout_seconds=10, progress=None,
+                       foreground=False):
+    """リネーム候補を提示する。戻り値は (確定した名前, 全体中止されたか)。
+
+    timeout_seconds に None を渡すとタイムアウトしない（手動モード）。
+    """
+    app = _ensure_app(foreground=foreground)
     ns_app = NSApplication.sharedApplication()
 
-    dialog = RenameDialog(candidates, filepath, timeout_seconds)
+    dialog = RenameDialog(candidates, filepath, timeout_seconds, progress)
     # Accessoryではウィンドウが自動で前面に来ないため、明示的にフォーカスを取る
     dialog.show()
     dialog.raise_()
@@ -313,4 +408,4 @@ def show_rename_dialog(candidates, filepath=None, timeout_seconds=10):
     # 閉じた後は前面から退き、フォーカスを元のアプリへ返す
     ns_app.deactivate()
 
-    return dialog.selected_name
+    return dialog.selected_name, dialog.aborted

--- a/popup_ui.py
+++ b/popup_ui.py
@@ -1,4 +1,5 @@
 import os
+import signal
 import sys
 from AppKit import NSApplication, NSApplicationActivationPolicyAccessory
 from PyQt6.QtWidgets import (
@@ -247,14 +248,60 @@ class RenameDialog(QDialog):
         self.accept()
 
 
-def show_rename_dialog(candidates, filepath=None, timeout_seconds=10):
+# QApplicationをローカル変数だけで持つと関数を抜けた時点で破棄される。
+# NSApplication側はGUIアプリとして登録されたまま残るため、イベントを捌く主体が
+# 居ない状態になり、レインボーカーソルの原因になる。プロセス全体で保持する。
+_app = None
+
+
+def _ensure_app():
+    """QApplicationを取得（無ければ生成）し、常駐ツールとしての体裁を整える。"""
+    global _app
     app = QApplication.instance() or QApplication(sys.argv)
+    _app = app
 
     # QApplicationを生成するとプロセスが通常のGUIアプリ扱いになり、Dockアイコンと
     # メニューバーを占有したまま常駐してしまう。メニューバー常駐アプリと同じ
     # Accessory に変更し、Dockに居座らせない。
+    NSApplication.sharedApplication().setActivationPolicy_(
+        NSApplicationActivationPolicyAccessory
+    )
+
+    # これが無いと、リネームのダイアログを閉じた時点で「最後のウィンドウが閉じた」と
+    # 判断され、常駐プロセスごと終了してしまう。
+    app.setQuitOnLastWindowClosed(False)
+    return app
+
+
+def run_event_loop(on_tick, interval_ms=500):
+    """Cocoaのイベントを処理し続けるメインループ。
+
+    自前の while ループで待機すると、GUIアプリとして登録されているのにイベント
+    キューを処理しないプロセスになり、macOSから応答なしと判断されてレインボー
+    カーソルの原因になる。待機中もイベントループを回し続ける必要がある。
+    """
+    app = _ensure_app()
+
+    # Qtのイベントループ実行中はPythonのシグナルハンドラが動かないが、
+    # 定期的に発火するタイマーでPython側へ制御が戻るため Ctrl+C が効く
+    signal.signal(signal.SIGINT, lambda *_: app.quit())
+
+    timer = QTimer()
+    timer.timeout.connect(on_tick)
+    timer.start(interval_ms)
+
+    app.exec()
+
+
+def stop_event_loop():
+    app = QApplication.instance()
+    if app:
+        app.quit()
+
+
+def show_rename_dialog(candidates, filepath=None, timeout_seconds=10):
+    app = _ensure_app()
     ns_app = NSApplication.sharedApplication()
-    ns_app.setActivationPolicy_(NSApplicationActivationPolicyAccessory)
 
     dialog = RenameDialog(candidates, filepath, timeout_seconds)
     # Accessoryではウィンドウが自動で前面に来ないため、明示的にフォーカスを取る

--- a/popup_ui.py
+++ b/popup_ui.py
@@ -1,3 +1,4 @@
+import os
 import sys
 from AppKit import NSApplication, NSApplicationActivationPolicyAccessory
 from PyQt6.QtWidgets import (
@@ -5,12 +6,61 @@ from PyQt6.QtWidgets import (
     QHBoxLayout, QFrame
 )
 from PyQt6.QtCore import QSize, QTimer, Qt
-from PyQt6.QtGui import QFont, QFontMetrics
+from PyQt6.QtGui import QFont, QFontMetrics, QPixmap
 
 # ダイアログの初期サイズ。画面が小さい場合は SCREEN_RATIO まで縮める
 DEFAULT_WIDTH = 1280
 DEFAULT_HEIGHT = 760
 SCREEN_RATIO = 0.9
+
+
+class PreviewPane(QLabel):
+    """対象ファイルの中身を表示する。枠のサイズは変えず、中身をアスペクト比維持で収める。"""
+
+    def __init__(self, filepath):
+        super().__init__()
+        self.filepath = filepath
+        self.source = self._load(filepath)
+
+        self.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.setMinimumHeight(160)
+        self.setStyleSheet(
+            "background-color: #000000; border: 1px solid #3A3A3C; border-radius: 6px;"
+        )
+
+        if self.source is None:
+            # プレビューが出せなくてもリネーム操作は続行できるようにする
+            self.setFont(QFont("SF Pro Text", 11))
+            name = os.path.basename(filepath) if filepath else ""
+            self.setText("\n".join(filter(None, ["プレビューを表示できません", name])))
+
+    def _load(self, filepath):
+        if not filepath or not os.path.exists(filepath):
+            return None
+        pixmap = QPixmap(filepath)
+        return None if pixmap.isNull() else pixmap
+
+    def _rescale(self):
+        if self.source is None:
+            return
+
+        # Retinaでぼやけないよう実ピクセルで拡縮し、描画時の倍率を戻す
+        ratio = self.devicePixelRatioF()
+        target = QSize(
+            max(int(self.width() * ratio), 1),
+            max(int(self.height() * ratio), 1),
+        )
+        scaled = self.source.scaled(
+            target,
+            Qt.AspectRatioMode.KeepAspectRatio,
+            Qt.TransformationMode.SmoothTransformation,
+        )
+        scaled.setDevicePixelRatio(ratio)
+        self.setPixmap(scaled)
+
+    def resizeEvent(self, event):
+        self._rescale()
+        super().resizeEvent(event)
 
 
 class CandidateCard(QFrame):
@@ -54,9 +104,10 @@ class CandidateCard(QFrame):
 
 
 class RenameDialog(QDialog):
-    def __init__(self, candidates, timeout_seconds=10):
+    def __init__(self, candidates, filepath=None, timeout_seconds=10):
         super().__init__()
         self.candidates = candidates
+        self.filepath = filepath
         self.time_left = timeout_seconds
         self.selected_name = None
         self.cards = []
@@ -95,13 +146,16 @@ class RenameDialog(QDialog):
         self.timer_label.setStyleSheet("color: #0A84FF;")
         layout.addWidget(self.timer_label)
 
+        # --- プレビュー ---
+        # 余った領域は全てプレビューに割り当てる。ウィンドウを広げた分だけ大きく見える
+        self.preview = PreviewPane(self.filepath)
+        layout.addWidget(self.preview, stretch=1)
+
         # --- 候補リスト ---
         for cand in self.candidates:
             card = CandidateCard(cand, self)
             layout.addWidget(card)
             self.cards.append(card)
-
-        layout.addStretch()
 
         # --- フッター ---
         footer_layout = QHBoxLayout()
@@ -179,7 +233,7 @@ class RenameDialog(QDialog):
         self.accept()
 
 
-def show_rename_dialog(candidates, timeout_seconds=10):
+def show_rename_dialog(candidates, filepath=None, timeout_seconds=10):
     app = QApplication.instance() or QApplication(sys.argv)
 
     # QApplicationを生成するとプロセスが通常のGUIアプリ扱いになり、Dockアイコンと
@@ -188,7 +242,7 @@ def show_rename_dialog(candidates, timeout_seconds=10):
     ns_app = NSApplication.sharedApplication()
     ns_app.setActivationPolicy_(NSApplicationActivationPolicyAccessory)
 
-    dialog = RenameDialog(candidates, timeout_seconds)
+    dialog = RenameDialog(candidates, filepath, timeout_seconds)
     # Accessoryではウィンドウが自動で前面に来ないため、明示的にフォーカスを取る
     dialog.show()
     dialog.raise_()

--- a/popup_ui.py
+++ b/popup_ui.py
@@ -189,7 +189,7 @@ class RenameDialog(QDialog):
         return QSize(max(width, 1), max(height, 1))
 
     def init_ui(self):
-        self.setWindowTitle("Screenshot Renamer")
+        self.setWindowTitle("Smart Renamer")
         self.setStyleSheet("background-color: #1E1E1E; color: #FFFFFF;")
         self.setWindowFlags(Qt.WindowType.WindowStaysOnTopHint)
         self.setSizeGripEnabled(True)

--- a/popup_ui.py
+++ b/popup_ui.py
@@ -5,13 +5,17 @@ from PyQt6.QtWidgets import (
     QApplication, QDialog, QVBoxLayout, QLabel,
     QHBoxLayout, QFrame
 )
-from PyQt6.QtCore import QSize, QTimer, Qt
+from PyQt6.QtCore import QSettings, QSize, QTimer, Qt
 from PyQt6.QtGui import QFont, QFontMetrics, QPixmap
 
 # ダイアログの初期サイズ。画面が小さい場合は SCREEN_RATIO まで縮める
 DEFAULT_WIDTH = 1280
 DEFAULT_HEIGHT = 760
 SCREEN_RATIO = 0.9
+
+# ウィンドウサイズの保存先。利用者が編集する設定ではないため config.yaml には置かない
+SETTINGS_ORG = "screenshot_renamer"
+SETTINGS_APP = "RenameDialog"
 
 
 class PreviewPane(QLabel):
@@ -112,18 +116,28 @@ class RenameDialog(QDialog):
         self.selected_name = None
         self.cards = []
         self.current_index = 0
+        self.settings = QSettings(SETTINGS_ORG, SETTINGS_APP)
 
         self.init_ui()
 
     def _initial_size(self):
-        """初期サイズ。画面をはみ出さないよう上限を設ける。"""
-        width, height = DEFAULT_WIDTH, DEFAULT_HEIGHT
+        """前回のサイズがあればそれを使う。無ければ既定値。画面をはみ出さないよう上限を設ける。"""
+        width = self.settings.value("width", DEFAULT_WIDTH, type=int)
+        height = self.settings.value("height", DEFAULT_HEIGHT, type=int)
+
         screen = QApplication.primaryScreen()
         if screen:
             available = screen.availableGeometry()
             width = min(width, int(available.width() * SCREEN_RATIO))
             height = min(height, int(available.height() * SCREEN_RATIO))
-        return QSize(width, height)
+
+        return QSize(max(width, 1), max(height, 1))
+
+    def done(self, result):
+        """閉じ方（選択・キャンセル・タイムアウト）に関わらず最後のサイズを覚える"""
+        self.settings.setValue("width", self.width())
+        self.settings.setValue("height", self.height())
+        super().done(result)
 
     def init_ui(self):
         self.setWindowTitle("Screenshot Renamer")


### PR DESCRIPTION
## Summary
- `--rename` による手動リネームモードを追加（任意のファイル・フォルダをその場でリネーム、Finder Quick Action対応）
- PDFのテキスト抽出・プレビュー表示に対応（テキスト層優先、無ければ先頭ページをVisionでOCR）
- リネームダイアログを刷新: 画像を全面プレビュー、候補を半透明パネルでオーバーレイ、↑↓で候補選択・Tabで編集モード・Enterで確定
- 常駐中にQtのイベントループを回さず固まっていた問題（レインボーカーソル化・Dock居座り）を修正
- リポジトリ名を `screenshot_renamer` → `smart-renamer` に変更（スクショ以外のファイルも扱うようになったため）

## 実機での検証状況（macOS 15.5 / Apple Silicon）
- レインボーカーソル解消: 6分以上のアイドル後もCPU 0%・応答性クエリ即答、アイドルタイムアウトで正常終了を確認
- PDF処理: テキスト層あり/なし（画像レンダリング+OCR）の両方で `extract_text` / `render_pdf_preview` が正常動作を確認。`CGImageForProposedRect_context_hints_` の戻り値がタプル固定であることを確認し、不要な分岐を削除
- HEIC: QPixmapでの読み込み・Vision OCRとも正常動作を確認
- UI操作（↑↓/Tab/Enter/Esc/クリック）: `QTest` による自動テストで18項目すべて確認。実機検証中に「前回のウィンドウサイズを別画像でも使い回して余白が出る」バグを発見し修正（#12）
- 手動モード: フォルダ直下展開・進捗表示・スキップ・中止・その場リネーム（save_dirへ移動しない）を自動テストで確認
- mtimeガード: 監視モード起動中に既存ファイルを手動リネームしてもポップアップが誤発火しないことを確認
- README: セットアップ手順に実在しないユーザー名のパスがハードコードされていたバグを発見・修正（#13）
- 未検証: Finder Quick Actionが実際に右クリックメニューに表示されるか（Shortcuts.appのGUI操作を自動化できず、Accessibility権限もないため）。利用者側での確認が必要

## Closes
Closes #6, #7, #9, #10, #11, #12, #13