### PR TITLE
feat(setup): setup.sh でセットアップを一括化し、常駐まわりの無言failureを潰す

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ cat << 'PLIST_EOF' > ~/Library/LaunchAgents/com.user.smart_renamer.plist
     <array>
         <string>/usr/bin/osascript</string>
         <string>-e</string>
-        <string>do shell script "cd /path/to/smart-renamer && .venv/bin/python main.py > app.log 2> app_error.log"</string>
+        <string>do shell script "cd /path/to/smart-renamer && .venv/bin/python -u main.py > app.log 2> app_error.log"</string>
     </array>
 
     <key>RunAtLoad</key>
@@ -182,6 +182,8 @@ PLIST_EOF
 ```
 
 ※ `WatchPaths` のパスは `config.yaml` の `watch_dir` と一致させてください（`~` は展開されないため絶対パスで記述します）。
+
+※ `python -u` は必須です。付けないと標準出力がバッファリングされ、常駐している間 `app.log` がほぼ空のままになり、障害が追えなくなります。
 
 ### 6-2. 権限設定と常駐登録
 ```bash

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ cd ~/Documents/smart-renamer
 | 仮想環境 | `.venv` の作成と `requirements.txt` のインストール |
 | APIキー | `.env` の作成（既にキーがあれば触りません） |
 | 常駐登録 | `.plist` を生成して `launchd` に登録。ログイン時に自動で動きます |
-| 右クリック | Finderの「クイックアクション」に `Rename with Gemini` を登録 |
+| 右クリック | Finderの「サービス」に `Rename with Gemini` を登録 |
 
 パスは全てスクリプトが埋めるため、プロジェクトをどこに置いても構いません。
 
@@ -88,18 +88,49 @@ cd ~/Documents/smart-renamer
 - 複数件のときは `3 / 50` の進捗が出ます。`Esc` でその1件をスキップ、「すべて中止」で残り全部を中止
 
 
-## 🖱 3. Finderの右クリックからリネームする（Quick Action）
+## 🖱 3. Finderの右クリックからリネームする
 
-`setup.sh` が Automator のクイックアクションを `~/Library/Services/Rename with Gemini.workflow` に作成済みです。Finderでファイルやフォルダを選んで右クリック →「クイックアクション」→「Rename with Gemini」で実行できます。
+`setup.sh` が Automator のサービスを `~/Library/Services/Rename with Gemini.workflow` に作成済みです。Finderでファイルやフォルダを選んで **右クリック →「サービス」→「Rename with Gemini」** で実行できます。
 
-メニューに出てこない場合:
+### メニューのどこに出るか
+
+macOS の右クリックメニューには「クイックアクション」と「サービス」の2つのサブメニューがあり、**登録方法によって出る場所が変わります。**
+
+| 登録方法 | 出る場所 | 並び順 | 自動登録 |
+| --- | --- | --- | --- |
+| Automator（`setup.sh`） | 「サービス」 | 名前順で固定 | できる |
+| ショートカット.app | 「クイックアクション」 | 変えられる | できない（GUI操作が必要） |
+
+「クイックアクション」は「サービス」より上に表示され、**システム設定 → 一般 → ログイン項目と機能拡張 → Finder** で並び順を変えられます。一番上に置きたい場合はショートカット.app で登録してください。
+
+Automator のサービスは `setup.sh` から自動生成できる代わりに、「サービス」サブメニュー内の名前順に固定されます。
+
+### メニューに出てこない場合
 
 - Finderを再起動する（`killall Finder`）
-- **システム設定 → 一般 → 機能拡張**（macOSのバージョンによっては「プライバシーとセキュリティ → 機能拡張」）の **Finder関連の拡張機能一覧** で、`Rename with Gemini` にチェックが入っているか確認する
+- **システム設定 → 一般 → ログイン項目と機能拡張**（macOSのバージョンによっては「プライバシーとセキュリティ → 機能拡張」）で、`Rename with Gemini` にチェックが入っているか確認する
+
+### `Operation not permitted` で失敗する場合
+
+```
+The action "Run Shell Script" encountered an error: "realpath: .venv/bin/: Operation not permitted"
+```
+
+サービスを実行するプロセス（`WorkflowServiceRunner`）が、プロジェクトのあるフォルダを読めていません。Desktop / Documents / Downloads 配下はmacOSの保護対象です。
+
+**システム設定 → プライバシーとセキュリティ → フルディスクアクセス** を開き、`+` から以下を追加して有効にしてください。
+
+```
+/System/Library/Frameworks/AppKit.framework/Versions/C/XPCServices/WorkflowServiceRunner.xpc
+```
+
+（`Cmd + Shift + G` でパスを直接入力できます）
+
+追加後、`killall Finder` して試し直してください。
 
 ### ショートカット.app で登録する場合
 
-Automator ではなくショートカット.app で管理したい場合は、こちらの手順でも同じことができます。`setup.sh` が作ったクイックアクションは `rm -rf ~/Library/Services/"Rename with Gemini.workflow"` で削除できます。
+「クイックアクション」に出したい場合、または並び順を変えたい場合はこちらです。`setup.sh` が作ったサービスは `rm -rf ~/Library/Services/"Rename with Gemini.workflow"` で削除できます。
 
 1. **ショートカット.app** を開き、新規ショートカットを作成
 2. 「クイックアクション」として登録し、**受け取る項目を「ファイルとフォルダ」**、**「Finder」から使用可能** に設定
@@ -110,15 +141,13 @@ Automator ではなくショートカット.app で管理したい場合は、�
    - シェルスクリプト（`/path/to/smart-renamer` は実際にこのプロジェクトを置いた場所に置き換える）:
 
 ```bash
-cd /path/to/smart-renamer
-.venv/bin/python main.py --rename "$@"
+/path/to/smart-renamer/.venv/bin/python /path/to/smart-renamer/main.py --rename "$@"
 ```
 
 4. ショートカットに名前を付けて保存（例: `Rename with Gemini`）
 
    この名前がFinderの右クリックメニューにそのまま表示されます。
-
-※ Desktop / Documents / Downloads 配下のファイルを操作するには、実行するPythonに**フルディスクアクセス**の許可が必要になる場合があります（システム設定 → プライバシーとセキュリティ → フルディスクアクセス）。
+5. **システム設定 → 一般 → ログイン項目と機能拡張 → Finder** で並び順を一番上にする
 
 
 ## ⚙️ 4. 常駐の管理 (launchd)
@@ -149,7 +178,8 @@ launchctl kickstart -k gui/$(id -u)/com.user.smart_renamer
 | `Bootstrap failed: 5: Input/output error` | 既に登録済み。`bootout` してから `bootstrap` する |
 | ファイル名が全て `0001_Capture.png` になる | `.env` の `GEMINI_API_KEY` を確認。未設定なら起動時に `app.log` にエラーが出る |
 | ポップアップが出ない | `app.log` / `app_error.log` を確認 |
-| 右クリックに出てこない | `killall Finder`、それでも駄目ならシステム設定の「機能拡張」 |
+| 右クリックに出てこない | 「クイックアクション」ではなく「サービス」を見る。`killall Finder` |
+| 右クリックが `Operation not permitted` | `WorkflowServiceRunner.xpc` にフルディスクアクセスを許可（→ 3章） |
 
 
 ## 📎 付録: 手動セットアップ

--- a/README.md
+++ b/README.md
@@ -21,10 +21,12 @@ PyQt6によるポップアップUIからキーボード（`↑`/`↓`/`Enter`）
 
 macOS専用です（Vision framework / PyObjC / PyQt6 に依存）。
 
+**設置場所は `~/Documents` / `~/Desktop` / `~/Downloads` の外にしてください。** この3つはmacOSの保護対象（TCC）で、Finderの右クリックからリネームを実行するプロセスが読み取れず失敗します。ホーム直下（`~/smart-renamer` など）が無難です。常駐だけなら保護対象でも動きますが、右クリックが使えません。
+
 事前に [Google AI Studio](https://aistudio.google.com/apikey) でGemini APIキー（`AIza...` から始まる文字列）を取得しておいてください。
 
 ```bash
-cd ~/Documents/smart-renamer
+cd ~/smart-renamer
 ./setup.sh
 ```
 
@@ -113,20 +115,22 @@ Automator のサービスは `setup.sh` から自動生成できる代わりに�
 ### `Operation not permitted` で失敗する場合
 
 ```
-The action "Run Shell Script" encountered an error: "realpath: .venv/bin/: Operation not permitted"
+PermissionError: [Errno 1] Operation not permitted: '/Users/you/Documents/smart-renamer/.venv/pyvenv.cfg'
 ```
 
-サービスを実行するプロセス（`WorkflowServiceRunner`）が、プロジェクトのあるフォルダを読めていません。Desktop / Documents / Downloads 配下はmacOSの保護対象です。
+プロジェクトを `~/Documents` / `~/Desktop` / `~/Downloads` に置いている場合に出ます。サービスを実行する `WorkflowServiceRunner` がこれらのフォルダを読めないためです。
 
-**システム設定 → プライバシーとセキュリティ → フルディスクアクセス** を開き、`+` から以下を追加して有効にしてください。
+**プロジェクトを保護対象外の場所へ移してください。**
 
+```bash
+launchctl bootout gui/$(id -u)/com.user.smart_renamer
+mv ~/Documents/smart-renamer ~/smart-renamer
+~/smart-renamer/setup.sh
 ```
-/System/Library/Frameworks/AppKit.framework/Versions/C/XPCServices/WorkflowServiceRunner.xpc
-```
 
-（`Cmd + Shift + G` でパスを直接入力できます）
+`setup.sh` が新しいパスで plist と サービス を貼り直します。
 
-追加後、`killall Finder` して試し直してください。
+権限を与えて解決しようとしても回避できません。`WorkflowServiceRunner.xpc` はフルディスクアクセスの選択ダイアログで選べず、`osascript` の `do shell script` を挟んでも TCC の帰属は変わりませんでした（macOS 26 で確認）。
 
 ### ショートカット.app で登録する場合
 
@@ -179,7 +183,7 @@ launchctl kickstart -k gui/$(id -u)/com.user.smart_renamer
 | ファイル名が全て `0001_Capture.png` になる | `.env` の `GEMINI_API_KEY` を確認。未設定なら起動時に `app.log` にエラーが出る |
 | ポップアップが出ない | `app.log` / `app_error.log` を確認 |
 | 右クリックに出てこない | 「クイックアクション」ではなく「サービス」を見る。`killall Finder` |
-| 右クリックが `Operation not permitted` | `WorkflowServiceRunner.xpc` にフルディスクアクセスを許可（→ 3章） |
+| 右クリックが `Operation not permitted` | プロジェクトが `~/Documents` などの保護対象にある。外へ移す（→ 3章） |
 
 
 ## 📎 付録: 手動セットアップ
@@ -189,7 +193,7 @@ launchctl kickstart -k gui/$(id -u)/com.user.smart_renamer
 ### A-1. 仮想環境と依存パッケージ
 
 ```bash
-cd ~/Documents/smart-renamer
+cd ~/smart-renamer
 python3 -m venv .venv
 .venv/bin/pip install -r requirements.txt
 ```

--- a/README.md
+++ b/README.md
@@ -17,86 +17,68 @@ PyQt6によるポップアップUIからキーボード（`↑`/`↓`/`Enter`）
 - **手動リネーム**: `--rename` で任意のファイル・フォルダをその場でリネーム。Finderの右クリックからも実行可能。候補の選択に加えて**自分で名前を書き換えられる**。`pdf` / `jpg` / `heic` にも対応。
 
 
-## 🚀 1. 仮想環境の作成と有効化
+## 🚀 1. セットアップ
 
-システム環境を汚さないために、Pythonの仮想環境（`.venv`）を作成して実行します。ターミナルを開き、以下のコマンドを順番に実行してください。
+macOS専用です（Vision framework / PyObjC / PyQt6 に依存）。
+
+事前に [Google AI Studio](https://aistudio.google.com/apikey) でGemini APIキー（`AIza...` から始まる文字列）を取得しておいてください。
 
 ```bash
-# プロジェクトのディレクトリに移動
 cd ~/Documents/smart-renamer
-
-# 仮想環境（.venv）を作成
-python3 -m venv .venv
-
-# 仮想環境を有効化（ターミナルの先頭に (.venv) と表示されれば成功です）
-source .venv/bin/activate
-```
-※以降の作業は、必ずこの仮想環境が有効化された状態で行ってください。
-
-## 📦 2. 必要なパッケージのインストール
-
-仮想環境を有効にした状態で、本ツールの動作に必要な外部ライブラリをインストールします。
-
-```bash
-pip install watchdog google-genai pyyaml python-dotenv PyQt6 pyobjc-framework-Cocoa pyobjc-framework-Quartz pyobjc-framework-Vision
+./setup.sh
 ```
 
-**【インストールされる主なパッケージ】**
+途中でAPIキーの入力を求められます。貼り付けて `Enter` を押すと `.env` に保存されます。
 
-- `watchdog`: デスクトップの新規スクリーンショット検知
-- `google-genai`: 新仕様のGemini APIクライアント
-- `PyQt6`: 高速かつ洗練されたGUIポップアップダイアログ
-- `pyyaml`: `config.yaml` の読み込み
-- `python-dotenv`: `.env` ファイルからのAPIキー読み込み
-- `pyobjc-framework-*`: Vision framework によるOCR（Cocoa / Quartz / Vision）
+`setup.sh` は以下を全て行います。
+
+| やること | 内容 |
+| --- | --- |
+| 仮想環境 | `.venv` の作成と `requirements.txt` のインストール |
+| APIキー | `.env` の作成（既にキーがあれば触りません） |
+| 常駐登録 | `.plist` を生成して `launchd` に登録。ログイン時に自動で動きます |
+| 右クリック | Finderの「クイックアクション」に `Rename with Gemini` を登録 |
+
+パスは全てスクリプトが埋めるため、プロジェクトをどこに置いても構いません。
+
+**何度実行しても安全です。** `config.yaml` の `watch_dir` を変えた後や、プロジェクトを別の場所へ移動した後は、`./setup.sh` を再実行すれば設定が追従します。
+
+※ 監視するフォルダや保存先、命名規則を変えたい場合は `config.yaml` を編集してください。
 
 
-## 🔐 3. APIキーの設定 (Configuration)
+## 💡 2. 使い方 (Usage)
 
-セキュリティを確保するため、APIキーはGitの管理対象外である `.env` ファイルに保存します。
-
-1. プロジェクトのルートディレクトリ（`~/Documents/smart-renamer`）に `.env` という名前のファイルを作成します。
-2. 取得したGoogle Gemini APIキーを以下のように記述して保存してください。
-
-```env
-# .env (このファイルはGitにはプッシュされません)
-GEMINI_API_KEY=ここにあなたのAPIキー(AIza...から始まる文字列)を貼り付けてください
-```
-
-※監視するフォルダや保存先、細かい命名規則の設定を変更したい場合は、同階層にある `config.yaml` を編集してください。
-
-## 💡 4. 使い方 (Usage)
-
-準備が完了したら、ツールを起動して実際にスクリーンショットを処理します。
-
-### ツールの起動
-ターミナルで仮想環境を有効にした状態（`.venv`）で、以下のコマンドを実行します。
-
-```bash
-python main.py
-```
-
-ターミナルに以下のように表示されれば、正常に起動し、監視がスタートしています。
-```text
-👀 監視を開始しました: ~/Desktop
-終了する場合は Ctrl+C を押してください。
-```
+セットアップが済んでいれば常駐は既に動いています。何もせずスクショを撮るだけです。
 
 ### 実行の流れ
+
 1. **スクショ撮影**: Macの標準機能（`Cmd + Shift + 3` または `4`）でスクリーンショットを撮影します。
 2. **自動検知とAI処理**: プログラムが画像を検知し、GeminiにOCRとファイル名の生成をリクエストします。
 3. **ポップアップ確認**: 画面にリネーム候補のポップアップが表示されます。
 4. **保存**: 最適な候補をクリック（またはタイムアウト）すると、`config.yaml` で指定したフォルダ（デフォルトは `~/Documents/Screenshots`）に自動でリネームされて移動します。
 
-ツールの実行を終了したい場合は、ターミナル上で `Ctrl + C` を押してください。
+### 手動で起動する
+
+常駐させず、ターミナルで動きを見ながら試したい場合。
+
+```bash
+.venv/bin/python main.py
+```
+
+```text
+👀 監視を開始しました: /Users/you/Desktop
+終了する場合は Ctrl+C を押してください。
+```
+
+終了は `Ctrl + C` です。
 
 ### 既存ファイルを手動でリネームする
 
 他のフォルダにあるファイルや、一度リネームしたファイルを付け直したい場合は `--rename` を使います。
 
 ```bash
-python main.py --rename ~/Documents/Screenshots/2026-08-18__SBI__口座管理_Capture.png
-python main.py --rename ~/Downloads          # フォルダ直下のファイルをまとめて
+.venv/bin/python main.py --rename ~/Documents/Screenshots/2026-08-18__SBI__口座管理_Capture.png
+.venv/bin/python main.py --rename ~/Downloads          # フォルダ直下のファイルをまとめて
 ```
 
 - 対応形式は `png` / `jpg` / `jpeg` / `heic` / `pdf`
@@ -105,9 +87,19 @@ python main.py --rename ~/Downloads          # フォルダ直下のファイル
 - タイムアウトはありません。候補を選ぶか、**編集欄で自分で書き換えて** `Enter` で確定します
 - 複数件のときは `3 / 50` の進捗が出ます。`Esc` でその1件をスキップ、「すべて中止」で残り全部を中止
 
-## 🖱 5. Finderの右クリックからリネームする（Quick Action）
 
-`--rename` をFinderの右クリックメニューに登録すると、ファイルを選んで即リネームできます。
+## 🖱 3. Finderの右クリックからリネームする（Quick Action）
+
+`setup.sh` が Automator のクイックアクションを `~/Library/Services/Rename with Gemini.workflow` に作成済みです。Finderでファイルやフォルダを選んで右クリック →「クイックアクション」→「Rename with Gemini」で実行できます。
+
+メニューに出てこない場合:
+
+- Finderを再起動する（`killall Finder`）
+- **システム設定 → 一般 → 機能拡張**（macOSのバージョンによっては「プライバシーとセキュリティ → 機能拡張」）の **Finder関連の拡張機能一覧** で、`Rename with Gemini` にチェックが入っているか確認する
+
+### ショートカット.app で登録する場合
+
+Automator ではなくショートカット.app で管理したい場合は、こちらの手順でも同じことができます。`setup.sh` が作ったクイックアクションは `rm -rf ~/Library/Services/"Rename with Gemini.workflow"` で削除できます。
 
 1. **ショートカット.app** を開き、新規ショートカットを作成
 2. 「クイックアクション」として登録し、**受け取る項目を「ファイルとフォルダ」**、**「Finder」から使用可能** に設定
@@ -126,24 +118,78 @@ cd /path/to/smart-renamer
 
    この名前がFinderの右クリックメニューにそのまま表示されます。
 
-5. ショートカットを保存しても右クリックメニューに出てこない場合、**システム設定 → 一般 → 機能拡張**（またはmacOSのバージョンによっては「プライバシーとセキュリティ → 機能拡張」）にある **Finder関連の拡張機能一覧** を開き、作成したショートカットにチェックが入っているか確認する
-
-   ※ この項目はGUI操作の自動化・実機確認ができていない。見つからない場合はmacOSのバージョンに応じて「機能拡張」を検索するか、システム設定内を確認すること。
-
-Finderでファイルやフォルダを選んで右クリック →「クイックアクション」から実行できます。メニューに出てこない場合は、Finderを再起動（`Option`キーを押しながらDockのFinderアイコンを右クリック → 「終了」、または `killall Finder`）してみてください。
-
 ※ Desktop / Documents / Downloads 配下のファイルを操作するには、実行するPythonに**フルディスクアクセス**の許可が必要になる場合があります（システム設定 → プライバシーとセキュリティ → フルディスクアクセス）。
 
-## ⚙️ 6. macOS ログイン時自動常駐化 (launchd)
 
-手動起動せず、Mac起動時にバックグラウンドで完全自動実行させる設定です。
+## ⚙️ 4. 常駐の管理 (launchd)
 
-### 6-1. launchd 用設定ファイル (.plist) の作成
+`setup.sh` が `~/Library/LaunchAgents/com.user.smart_renamer.plist` を登録済みです。
+
+```bash
+# 動作確認
+launchctl print gui/$(id -u)/com.user.smart_renamer
+
+# ログ確認
+cat app.log
+cat app_error.log
+
+# 停止
+launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.user.smart_renamer.plist
+
+# 再起動（plistを変えていない場合）
+launchctl kickstart -k gui/$(id -u)/com.user.smart_renamer
+```
+
+`plist` を作り直したい場合は `./setup.sh` を再実行してください（`bootout` してから登録し直します）。
+
+### うまく動かないとき
+
+| 症状 | 確認すること |
+| --- | --- |
+| `Bootstrap failed: 5: Input/output error` | 既に登録済み。`bootout` してから `bootstrap` する |
+| ファイル名が全て `0001_Capture.png` になる | `.env` の `GEMINI_API_KEY` を確認。未設定なら起動時に `app.log` にエラーが出る |
+| ポップアップが出ない | `app.log` / `app_error.log` を確認 |
+| 右クリックに出てこない | `killall Finder`、それでも駄目ならシステム設定の「機能拡張」 |
+
+
+## 📎 付録: 手動セットアップ
+
+`setup.sh` を使わず自分で組み立てる場合の手順です。
+
+### A-1. 仮想環境と依存パッケージ
+
+```bash
+cd ~/Documents/smart-renamer
+python3 -m venv .venv
+.venv/bin/pip install -r requirements.txt
+```
+
+**【インストールされる主なパッケージ】**
+
+- `watchdog`: デスクトップの新規スクリーンショット検知
+- `google-genai`: 新仕様のGemini APIクライアント
+- `PyQt6`: 高速かつ洗練されたGUIポップアップダイアログ
+- `pyyaml`: `config.yaml` の読み込み
+- `python-dotenv`: `.env` ファイルからのAPIキー読み込み
+- `pyobjc-framework-*`: Vision framework によるOCR（Cocoa / Quartz / Vision）
+
+### A-2. APIキー
+
+APIキーはGitの管理対象外である `.env` に保存します。プロジェクトのルートに作成してください。
+
+```env
+# .env (このファイルはGitにはプッシュされません)
+GEMINI_API_KEY=ここにあなたのAPIキー(AIza...から始まる文字列)を貼り付けてください
+```
+
+未設定のまま起動するとエラーを出して終了します。
+
+### A-3. launchd 用設定ファイル (.plist)
 
 ```bash
 cat << 'PLIST_EOF' > ~/Library/LaunchAgents/com.user.smart_renamer.plist
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "[http://www.apple.com/DTDs/PropertyList-1.0.dtd](http://www.apple.com/DTDs/PropertyList-1.0.dtd)">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>Label</key>
@@ -175,31 +221,17 @@ cat << 'PLIST_EOF' > ~/Library/LaunchAgents/com.user.smart_renamer.plist
 PLIST_EOF
 ```
 
+※ `/path/to/smart-renamer` は実際にこのプロジェクトを置いた場所に置き換えてください。
+
 ※ `WatchPaths` のパスは `config.yaml` の `watch_dir` と一致させてください（`~` は展開されないため絶対パスで記述します）。
 
 ※ `python -u` は必須です。付けないと標準出力がバッファリングされ、常駐している間 `app.log` がほぼ空のままになり、障害が追えなくなります。
 
 ※ `KeepAlive` は使いません。`config.yaml` や `.env` の設定ミスで起動時に終了した場合、10秒おきに再起動を繰り返してしまうためです。異常終了しても次のスクショ撮影時に `WatchPaths` で起動し直されます。
 
-### 6-2. 権限設定と常駐登録
+### A-4. 常駐登録
+
 ```bash
-# フォルダ権限の許可
 chmod 755 ~/Library/LaunchAgents
-
-# ユーザーセッションへ登録・起動
 launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.user.smart_renamer.plist
 ```
-
-### 6-3. 管理用コマンド
-動作確認: `launchctl list | grep smart_renamer` または `ps aux | grep main.py`
-
-サービス停止: `launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.user.smart_renamer.plist`
-
-再読み込み:
-
-```bash
-launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/com.user.smart_renamer.plist
-launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.user.smart_renamer.plist
-```
-
-ログ確認: `cat app_error.log`

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ cat << 'PLIST_EOF' > ~/Library/LaunchAgents/com.user.smart_renamer.plist
     <array>
         <string>/usr/bin/osascript</string>
         <string>-e</string>
-        <string>do shell script "cd /path/to/smart-renamer && .venv/bin/python -u main.py > app.log 2> app_error.log"</string>
+        <string>do shell script "cd /path/to/smart-renamer &amp;&amp; .venv/bin/python -u main.py &gt; app.log 2&gt; app_error.log"</string>
     </array>
 
     <key>RunAtLoad</key>
@@ -222,6 +222,8 @@ PLIST_EOF
 ```
 
 ※ `/path/to/smart-renamer` は実際にこのプロジェクトを置いた場所に置き換えてください。
+
+※ `&amp;&amp;` と `&gt;` はXMLのエスケープです。`&&` `>` に書き戻すとXMLとして不正になり、`launchctl` が読み込めません。作成後に `plutil -lint ~/Library/LaunchAgents/com.user.smart_renamer.plist` で確認してください。
 
 ※ `WatchPaths` のパスは `config.yaml` の `watch_dir` と一致させてください（`~` は展開されないため絶対パスで記述します）。
 

--- a/README.md
+++ b/README.md
@@ -159,14 +159,8 @@ cat << 'PLIST_EOF' > ~/Library/LaunchAgents/com.user.smart_renamer.plist
     <key>RunAtLoad</key>
     <true/>
 
-    <!-- 異常終了時のみ再起動する。アイドルタイムアウトによる正常終了では再起動しない -->
-    <key>KeepAlive</key>
-    <dict>
-        <key>SuccessfulExit</key>
-        <false/>
-    </dict>
-
-    <!-- 監視ディレクトリに変更があった時（＝スクショ撮影時）に launchd が再起動する -->
+    <!-- 監視ディレクトリに変更があった時（＝スクショ撮影時）に launchd が起動する。
+         起動に失敗した場合も、次のスクショまで再試行しない -->
     <key>WatchPaths</key>
     <array>
         <string>/Users/your-username/Desktop</string>
@@ -184,6 +178,8 @@ PLIST_EOF
 ※ `WatchPaths` のパスは `config.yaml` の `watch_dir` と一致させてください（`~` は展開されないため絶対パスで記述します）。
 
 ※ `python -u` は必須です。付けないと標準出力がバッファリングされ、常駐している間 `app.log` がほぼ空のままになり、障害が追えなくなります。
+
+※ `KeepAlive` は使いません。`config.yaml` や `.env` の設定ミスで起動時に終了した場合、10秒おきに再起動を繰り返してしまうためです。異常終了しても次のスクショ撮影時に `WatchPaths` で起動し直されます。
 
 ### 6-2. 権限設定と常駐登録
 ```bash

--- a/llm_client.py
+++ b/llm_client.py
@@ -15,13 +15,19 @@ MODEL_NAME = config.get("llm", {}).get("model", "gemini-3.1-flash-lite")
 # APIが詰まって無期限にブロックし続けるのを防ぐためのタイムアウト（秒）
 TIMEOUT_SECONDS = config.get("llm", {}).get("timeout_seconds", 15)
 
+API_KEY_ENV = "GEMINI_API_KEY"
+
+
+# APIキーを環境変数から取得する。未設定なら None を返す
+def get_api_key():
+    return os.environ.get(API_KEY_ENV)
+
 # Gemini APIを呼び出してファイル名の候補を取得する
 def get_filename_candidates(ocr_text: str, prompt_template: str) -> list:
     today_str = datetime.now().strftime("%Y-%m-%d")
     
-    # 環境変数からAPIキーを取得
-    api_key = os.environ.get("GEMINI_API_KEY")
-    
+    api_key = get_api_key()
+
     if not api_key:
         print("エラー: APIキーが設定されていません。(.envファイルを確認してください)")
         return None

--- a/llm_client.py
+++ b/llm_client.py
@@ -6,8 +6,10 @@ from google import genai
 from google.genai import types
 
 
-# yamlファイルを読み込む処理を追加
-with open("config.yaml", "r", encoding="utf-8") as f:
+# カレントディレクトリに依存しないよう、このファイルからの相対で解決する
+CONFIG_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "config.yaml")
+
+with open(CONFIG_PATH, "r", encoding="utf-8") as f:
     config = yaml.safe_load(f)
 
 # yamlから設定を取得（値がない場合のデフォルト値も設定）

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 from ocr_engine import extract_text, is_supported
-from llm_client import get_filename_candidates
+from llm_client import API_KEY_ENV, get_api_key, get_filename_candidates
 from popup_ui import run_event_loop, show_rename_dialog, stop_event_loop
 
 file_queue = queue.Queue()
@@ -254,6 +254,13 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     config = load_config()
+
+    # キーが無いと候補が取れず、全ファイルが無言で連番になる。
+    # API障害による連番フォールバックとは違い設定ミスは直らないので、起動時に弾く
+    if not get_api_key():
+        print(f"エラー: {API_KEY_ENV} が設定されていません。")
+        print(".env に GEMINI_API_KEY=<キー> を記述してください。")
+        exit(1)
 
     # 手動モード: 常駐せず、渡されたファイルを処理して終了する
     if args.rename:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+watchdog
+google-genai
+pyyaml
+python-dotenv
+PyQt6
+pyobjc-framework-Cocoa
+pyobjc-framework-Quartz
+pyobjc-framework-Vision

--- a/setup.sh
+++ b/setup.sh
@@ -141,6 +141,16 @@ cat > "$QUICK_ACTION_PATH/Contents/Info.plist" << INFO_EOF
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.user.smart-renamer.quickaction</string>
+    <key>CFBundleName</key>
+    <string>$QUICK_ACTION_NAME</string>
+    <key>CFBundlePackageType</key>
+    <string>BNDL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
     <key>NSServices</key>
     <array>
         <dict>
@@ -151,11 +161,6 @@ cat > "$QUICK_ACTION_PATH/Contents/Info.plist" << INFO_EOF
             </dict>
             <key>NSMessage</key>
             <string>runWorkflowAsService</string>
-            <key>NSRequiredContext</key>
-            <dict>
-                <key>NSApplicationIdentifier</key>
-                <string>com.apple.finder</string>
-            </dict>
             <key>NSSendFileTypes</key>
             <array>
                 <string>public.item</string>
@@ -228,8 +233,7 @@ cat > "$QUICK_ACTION_PATH/Contents/document.wflow" << WFLOW_EOF
                 <key>ActionParameters</key>
                 <dict>
                     <key>COMMAND_STRING</key>
-                    <string>cd "$PROJECT_DIR"
-.venv/bin/python main.py --rename "\$@"</string>
+                    <string>"$PROJECT_DIR/.venv/bin/python" "$PROJECT_DIR/main.py" --rename "\$@"</string>
                     <key>CheckedForUserDefaultShell</key>
                     <true/>
                     <key>inputMethod</key>
@@ -281,17 +285,13 @@ cat > "$QUICK_ACTION_PATH/Contents/document.wflow" << WFLOW_EOF
     <key>workflowMetaData</key>
     <dict>
         <key>serviceApplicationBundleID</key>
-        <string>com.apple.finder</string>
-        <key>serviceApplicationName</key>
-        <string>Finder</string>
+        <string></string>
         <key>serviceInputTypeIdentifier</key>
         <string>com.apple.Automator.fileSystemObject</string>
         <key>serviceOutputTypeIdentifier</key>
         <string>com.apple.Automator.nothing</string>
         <key>serviceProcessesInput</key>
         <integer>0</integer>
-        <key>presentationMode</key>
-        <integer>11</integer>
         <key>workflowTypeIdentifier</key>
         <string>com.apple.Automator.servicesMenu</string>
     </dict>

--- a/setup.sh
+++ b/setup.sh
@@ -131,7 +131,7 @@ info "$PLIST_PATH を登録しました"
 
 
 # 4. Finderの右クリックメニュー（Automator の Quick Action）
-step "Finderの右クリックメニュー（Quick Action）"
+step "Finderの右クリックメニュー（サービス）"
 
 rm -rf "$QUICK_ACTION_PATH"
 mkdir -p "$QUICK_ACTION_PATH/Contents"
@@ -310,7 +310,11 @@ info "「${QUICK_ACTION_NAME}」を登録しました"
 step "セットアップ完了"
 info "常駐:       launchctl print gui/$(id -u)/$LAUNCHD_LABEL"
 info "ログ:       $PROJECT_DIR/app.log"
-info "右クリック: Finderでファイルを選択 →「クイックアクション」→「${QUICK_ACTION_NAME}」"
+info "右クリック: Finderでファイルを選択 →「サービス」→「${QUICK_ACTION_NAME}」"
 printf '\n'
-warn "右クリックメニューに出てこない場合は Finder を再起動してください: killall Finder"
-warn "初回実行時に、Desktop / Documents などへのアクセス許可を求められることがあります"
+warn "メニューに出てこない場合は Finder を再起動してください: killall Finder"
+warn "Operation not permitted で失敗する場合は、システム設定 → プライバシーとセキュリティ →"
+warn "フルディスクアクセス に WorkflowServiceRunner を追加してください"
+warn "（$PROJECT_DIR がDesktop/Documents/Downloads配下にある場合に必要です）"
+warn "「クイックアクション」の側に、より上位に出したい場合は README の"
+warn "「ショートカット.app で登録する場合」を参照してください"

--- a/setup.sh
+++ b/setup.sh
@@ -6,7 +6,7 @@
 #
 set -euo pipefail
 
-PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
 VENV_DIR="$PROJECT_DIR/.venv"
 ENV_FILE="$PROJECT_DIR/.env"
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,316 @@
+#!/bin/bash
+#
+# smart-renamer のセットアップ。
+# 仮想環境・APIキー・常駐登録・Finderの右クリックメニューまでを一括で行う。
+# 何度実行しても同じ結果になる（冪等）。
+#
+set -euo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VENV_DIR="$PROJECT_DIR/.venv"
+ENV_FILE="$PROJECT_DIR/.env"
+
+LAUNCHD_LABEL="com.user.smart_renamer"
+PLIST_PATH="$HOME/Library/LaunchAgents/$LAUNCHD_LABEL.plist"
+
+QUICK_ACTION_NAME="Rename with Gemini"
+QUICK_ACTION_PATH="$HOME/Library/Services/$QUICK_ACTION_NAME.workflow"
+
+step() { printf '\n\033[1m▶ %s\033[0m\n' "$1"; }
+info() { printf '  %s\n' "$1"; }
+warn() { printf '  \033[33m⚠️  %s\033[0m\n' "$1"; }
+
+if [ "$(uname -s)" != "Darwin" ]; then
+    echo "エラー: macOS 専用です（Vision framework / PyObjC / PyQt6 に依存）。" >&2
+    exit 1
+fi
+
+
+# 1. 仮想環境と依存パッケージ
+step "仮想環境と依存パッケージ"
+
+if [ ! -x "$VENV_DIR/bin/python" ]; then
+    info "$VENV_DIR を作成します"
+    python3 -m venv "$VENV_DIR"
+else
+    info "既存の $VENV_DIR を使います"
+fi
+
+info "requirements.txt をインストール中..."
+"$VENV_DIR/bin/pip" install --quiet --upgrade pip
+"$VENV_DIR/bin/pip" install --quiet -r "$PROJECT_DIR/requirements.txt"
+info "完了"
+
+
+# 2. APIキー
+step "Gemini APIキー"
+
+if [ -f "$ENV_FILE" ] && grep -qE '^GEMINI_API_KEY=.+' "$ENV_FILE"; then
+    info ".env に設定済みです。変更しません"
+elif [ ! -t 0 ]; then
+    warn ".env が未設定です。対話実行できないためスキップします"
+    warn "後で $ENV_FILE に GEMINI_API_KEY=<キー> を記述してください"
+else
+    info "https://aistudio.google.com/apikey で取得したキーを貼り付けてください"
+    info "（入力は表示されません。空のまま Enter でスキップ）"
+    printf '  GEMINI_API_KEY: '
+    read -r -s api_key
+    printf '\n'
+
+    if [ -z "$api_key" ]; then
+        warn "スキップしました。キーが無いとファイル名は連番になります"
+    else
+        # 既存の .env を壊さないよう、古い行だけ落として追記する
+        if [ -f "$ENV_FILE" ]; then
+            grep -vE '^GEMINI_API_KEY=' "$ENV_FILE" > "$ENV_FILE.tmp" || true
+            mv "$ENV_FILE.tmp" "$ENV_FILE"
+        fi
+        printf 'GEMINI_API_KEY=%s\n' "$api_key" >> "$ENV_FILE"
+        chmod 600 "$ENV_FILE"
+        info ".env に保存しました"
+    fi
+fi
+
+
+# 3. launchd への常駐登録
+step "常駐の登録（launchd）"
+
+# WatchPaths は config.yaml の watch_dir と一致させる必要がある。
+# チルダは launchd が展開しないため、絶対パスに直してから埋め込む。
+watch_dir="$("$VENV_DIR/bin/python" - "$PROJECT_DIR/config.yaml" <<'PY'
+import os, sys, yaml
+with open(sys.argv[1], encoding="utf-8") as f:
+    config = yaml.safe_load(f)
+print(os.path.expanduser(config["directories"]["watch_dir"]))
+PY
+)"
+info "監視先: $watch_dir"
+
+mkdir -p "$HOME/Library/LaunchAgents"
+chmod 755 "$HOME/Library/LaunchAgents"
+
+cat > "$PLIST_PATH" << PLIST_EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>$LAUNCHD_LABEL</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/bin/osascript</string>
+        <string>-e</string>
+        <string>do shell script "cd $PROJECT_DIR &amp;&amp; .venv/bin/python -u main.py &gt; app.log 2&gt; app_error.log"</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <!-- 監視ディレクトリに変更があった時（＝スクショ撮影時）に launchd が起動する。
+         起動に失敗した場合も、次のスクショまで再試行しない -->
+    <key>WatchPaths</key>
+    <array>
+        <string>$watch_dir</string>
+    </array>
+
+    <key>LimitLoadToSessionType</key>
+    <array>
+        <string>Aqua</string>
+    </array>
+</dict>
+</plist>
+PLIST_EOF
+
+plutil -lint "$PLIST_PATH" > /dev/null
+
+# 登録済みなら一度外さないと bootstrap が Input/output error になる
+launchctl bootout "gui/$(id -u)/$LAUNCHD_LABEL" 2>/dev/null || true
+launchctl bootstrap "gui/$(id -u)" "$PLIST_PATH"
+info "$PLIST_PATH を登録しました"
+
+
+# 4. Finderの右クリックメニュー（Automator の Quick Action）
+step "Finderの右クリックメニュー（Quick Action）"
+
+rm -rf "$QUICK_ACTION_PATH"
+mkdir -p "$QUICK_ACTION_PATH/Contents"
+
+cat > "$QUICK_ACTION_PATH/Contents/Info.plist" << INFO_EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSServices</key>
+    <array>
+        <dict>
+            <key>NSMenuItem</key>
+            <dict>
+                <key>default</key>
+                <string>$QUICK_ACTION_NAME</string>
+            </dict>
+            <key>NSMessage</key>
+            <string>runWorkflowAsService</string>
+            <key>NSRequiredContext</key>
+            <dict>
+                <key>NSApplicationIdentifier</key>
+                <string>com.apple.finder</string>
+            </dict>
+            <key>NSSendFileTypes</key>
+            <array>
+                <string>public.item</string>
+            </array>
+        </dict>
+    </array>
+</dict>
+</plist>
+INFO_EOF
+
+cat > "$QUICK_ACTION_PATH/Contents/document.wflow" << WFLOW_EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>AMApplicationBuild</key>
+    <string>528</string>
+    <key>AMApplicationVersion</key>
+    <string>2.10</string>
+    <key>AMDocumentVersion</key>
+    <string>2</string>
+    <key>actions</key>
+    <array>
+        <dict>
+            <key>action</key>
+            <dict>
+                <key>AMAccepts</key>
+                <dict>
+                    <key>Container</key>
+                    <string>List</string>
+                    <key>Optional</key>
+                    <true/>
+                    <key>Types</key>
+                    <array>
+                        <string>com.apple.cocoa.string</string>
+                    </array>
+                </dict>
+                <key>AMActionVersion</key>
+                <string>2.0.3</string>
+                <key>AMApplication</key>
+                <array>
+                    <string>Automator</string>
+                </array>
+                <key>AMParameterProperties</key>
+                <dict>
+                    <key>COMMAND_STRING</key>
+                    <dict/>
+                    <key>CheckedForUserDefaultShell</key>
+                    <dict/>
+                    <key>inputMethod</key>
+                    <dict/>
+                    <key>shell</key>
+                    <dict/>
+                    <key>source</key>
+                    <dict/>
+                </dict>
+                <key>AMProvides</key>
+                <dict>
+                    <key>Container</key>
+                    <string>List</string>
+                    <key>Types</key>
+                    <array>
+                        <string>com.apple.cocoa.string</string>
+                    </array>
+                </dict>
+                <key>ActionBundlePath</key>
+                <string>/System/Library/Automator/Run Shell Script.action</string>
+                <key>ActionName</key>
+                <string>Run Shell Script</string>
+                <key>ActionParameters</key>
+                <dict>
+                    <key>COMMAND_STRING</key>
+                    <string>cd "$PROJECT_DIR"
+.venv/bin/python main.py --rename "\$@"</string>
+                    <key>CheckedForUserDefaultShell</key>
+                    <true/>
+                    <key>inputMethod</key>
+                    <integer>1</integer>
+                    <key>shell</key>
+                    <string>/bin/zsh</string>
+                    <key>source</key>
+                    <string></string>
+                </dict>
+                <key>BundleIdentifier</key>
+                <string>com.apple.RunShellScript</string>
+                <key>CFBundleVersion</key>
+                <string>2.0.3</string>
+                <key>CanShowSelectedItemsWhenRun</key>
+                <false/>
+                <key>CanShowWhenRun</key>
+                <true/>
+                <key>Category</key>
+                <array>
+                    <string>AMCategoryUtilities</string>
+                </array>
+                <key>Class Name</key>
+                <string>RunShellScriptAction</string>
+                <key>InputUUID</key>
+                <string>$(uuidgen)</string>
+                <key>OutputUUID</key>
+                <string>$(uuidgen)</string>
+                <key>UUID</key>
+                <string>$(uuidgen)</string>
+                <key>UnlocalizedApplications</key>
+                <array>
+                    <string>Automator</string>
+                </array>
+                <key>arguments</key>
+                <dict/>
+                <key>isViewVisible</key>
+                <integer>1</integer>
+                <key>location</key>
+                <string>309.000000:253.000000</string>
+                <key>nibPath</key>
+                <string>/System/Library/Automator/Run Shell Script.action/Contents/Resources/Base.lproj/main.nib</string>
+            </dict>
+            <key>isViewVisible</key>
+            <integer>1</integer>
+        </dict>
+    </array>
+    <key>connectors</key>
+    <dict/>
+    <key>workflowMetaData</key>
+    <dict>
+        <key>serviceApplicationBundleID</key>
+        <string>com.apple.finder</string>
+        <key>serviceApplicationName</key>
+        <string>Finder</string>
+        <key>serviceInputTypeIdentifier</key>
+        <string>com.apple.Automator.fileSystemObject</string>
+        <key>serviceOutputTypeIdentifier</key>
+        <string>com.apple.Automator.nothing</string>
+        <key>serviceProcessesInput</key>
+        <integer>0</integer>
+        <key>presentationMode</key>
+        <integer>11</integer>
+        <key>workflowTypeIdentifier</key>
+        <string>com.apple.Automator.servicesMenu</string>
+    </dict>
+</dict>
+</plist>
+WFLOW_EOF
+
+plutil -lint "$QUICK_ACTION_PATH/Contents/Info.plist" > /dev/null
+plutil -lint "$QUICK_ACTION_PATH/Contents/document.wflow" > /dev/null
+
+# Services メニューのキャッシュを更新する
+/System/Library/CoreServices/pbs -update 2>/dev/null || true
+info "「${QUICK_ACTION_NAME}」を登録しました"
+
+
+step "セットアップ完了"
+info "常駐:       launchctl print gui/$(id -u)/$LAUNCHD_LABEL"
+info "ログ:       $PROJECT_DIR/app.log"
+info "右クリック: Finderでファイルを選択 →「クイックアクション」→「${QUICK_ACTION_NAME}」"
+printf '\n'
+warn "右クリックメニューに出てこない場合は Finder を再起動してください: killall Finder"
+warn "初回実行時に、Desktop / Documents などへのアクセス許可を求められることがあります"


### PR DESCRIPTION
新しく落としてきた人が `./setup.sh` 1コマンドでサービス開始できるようにした。あわせて、途中で見つかった「無言で失敗する」4件を潰している。

Closes #18
Fixes #19
Fixes #20
Fixes #21
Fixes #23

## 変更点

### `setup.sh`（新規）

| やること | 内容 |
| --- | --- |
| 仮想環境 | `.venv` の作成と `requirements.txt` のインストール |
| APIキー | `.env` が無ければ対話入力して作成（既存キーがあれば触らない） |
| 常駐登録 | 実行時のパスと `config.yaml` の `watch_dir` から plist を生成し `launchd` に登録 |
| 右クリック | Automator のサービスを `~/Library/Services/` に生成 |

環境依存の値は全てスクリプトが埋めるため、置き場所を問わない。何度実行しても同じ結果になる。

### 併せて潰した無言failure

- **#19** plist が stdout をリダイレクトするため Python がブロックバッファリングになり、常駐中 `app.log` が 0 バイトのままだった。`python -u` にした。
- **#20** `GEMINI_API_KEY` 未設定でも起動し、全ファイルが無言で `0001_Capture.png` 形式の連番になっていた。設定ミスは起動時に弾く。API障害時の連番フォールバックは従来どおり残す。
  - これに伴い plist から `KeepAlive` を外した。`SuccessfulExit=false` のままだと設定ミスで10秒おきの再起動ループになる。`WatchPaths` があるので次のスクショで起動し直される。
- **#21** README の plist テンプレートが `&&` を XML エスケープしておらず、貼り付けて作った plist は `launchctl` が読めなかった。
- **#23** `llm_client` が `config.yaml` を相対パスで開いており、プロジェクト外から起動すると落ちた。右クリック実行を `cd` 無しの絶対パス起動にするために修正。

### 右クリックメニューについて分かったこと

macOS 26 で確認したところ、**登録方法によって出るサブメニューが違う。**

| 登録方法 | 出る場所 | 並び順 | 自動登録 |
| --- | --- | --- | --- |
| Automator（`setup.sh`） | 「サービス」 | 名前順で固定 | できる |
| ショートカット.app | 「クイックアクション」 | 変えられる | できない（GUI操作が必要） |

`~/Library/Services/*.workflow` は「サービス」に入る。「クイックアクション」は Finder の App Extension とショートカット.app からのみ populate される（`defaults read pbs` の `FinderActive` で確認）。

`setup.sh` は自動化できる Automator 方式を既定にしつつ、上位に出したい人向けにショートカット.app の手順も README に残した。

### `requirements.txt`（新規）

パッケージ名を README と `setup.sh` で二重管理しないため。

## 確認したこと

Mac実機（macOS 26.5.1）で確認済み。

- `./setup.sh` を複数回連続実行して同じ結果になること
- `launchctl print` で `state = running`、`runs` が増えないこと（再起動ループなし）
- `-u` を入れた後 `app.log` が即時書かれること。実際にスクショ1件が
  `2026-09-01__Work__smart-renamer_development_log_Capture.png` にリネームされるところまで
- キー未設定時に監視モード・手動モードとも `exit 1` すること
- サービスが `pbs -read_bundle` / `pbs -dump_pboard` に登録され、Finderの右クリック →「サービス」に表示されること
- 保護対象外に移した状態で、Finderの右クリックからリネームが最後まで通ること
- `cd /tmp` から絶対パスで `main.py --rename` が動くこと（#23 の確認）
- 空の `.venv` を作り直して `requirements.txt` から全依存が import できること
- README の plist テンプレートを抜き出して `plutil -lint` が OK になること

### 設置場所の制約（TCC）

`WorkflowServiceRunner` は `~/Documents` / `~/Desktop` / `~/Downloads` を読めないため、プロジェクトをこの3つの下に置くと右クリック実行が `.venv/pyvenv.cfg` の時点で `Operation not permitted` になる。

権限付与では回避できないことを確認した。

- `WorkflowServiceRunner.xpc` はフルディスクアクセスの選択ダイアログで選べない（アプリ以外はグレーアウト）
- `osascript` の `do shell script` を挟んでも TCC の帰属は変わらない

そのため README では**保護対象外の場所への設置**を案内している。実際に `~/Documents/smart-renamer` → `~/smart-renamer` へ移して `./setup.sh` を再実行し、Finderの右クリックからリネームが通ることを確認済み。

あわせて `setup.sh` の `pwd` を `pwd -P` にした。旧パスにシンボリックリンクを残す運用で、リンク側のパスを埋め戻さないようにするため。

**注意**: このPRを取り込んだ後は `.env` に `GEMINI_API_KEY` が無いと常駐が起動しなくなる。`./setup.sh` を実行してキーを設定すること。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013sRAJor8Z5Yf41NCEKYJtT
