### PR TITLE
feat(naming): 元ファイルの日付を候補に反映する

### DIFF
--- a/main.py
+++ b/main.py
@@ -172,13 +172,79 @@ def rename_manually(paths, config):
             print("↩︎ スキップしました。")
 
 
+# ファイル名に含まれる日付。区切りの有無と種類だけが違う
+DATE_PATTERNS = [
+    re.compile(r"(?<!\d)(\d{4})-(\d{2})-(\d{2})(?!\d)"),
+    re.compile(r"(?<!\d)(\d{4})_(\d{2})_(\d{2})(?!\d)"),
+    re.compile(r"(?<!\d)(\d{4})(\d{2})(\d{2})(?!\d)"),
+]
+
+
+def extract_date_from_name(filepath):
+    """ファイル名に含まれる日付を YYYY-MM-DD で返す。見つからなければ None。"""
+    stem = os.path.splitext(os.path.basename(filepath))[0]
+    for pattern in DATE_PATTERNS:
+        for year, month, day in pattern.findall(stem):
+            try:
+                return datetime(int(year), int(month), int(day)).strftime("%Y-%m-%d")
+            except ValueError:
+                # 8桁の数字が金額や連番だった場合。次の候補を試す
+                continue
+    return None
+
+
+def get_file_date(filepath):
+    """対象ファイルの日付。ファイル名の日付を優先し、無ければ作成日時を使う。"""
+    from_name = extract_date_from_name(filepath)
+    if from_name:
+        return from_name
+
+    stat = os.stat(filepath)
+    # macOSでは作成日時が取れる。取れない場合のみ更新日時にフォールバックする
+    timestamp = getattr(stat, "st_birthtime", stat.st_mtime)
+    return datetime.fromtimestamp(timestamp).strftime("%Y-%m-%d")
+
+
+def prefer_file_date(candidates, file_date, today):
+    """本日の日付で生成された候補を、最後の1件を残してファイルの日付に差し替える。
+
+    OCR本文から日付を読み取れた候補は本日の日付にならないため、そのまま残る。
+    内容由来の日付の方が正しく、書き換えると壊れるため触らない。
+    本日の日付の候補を1件残すのは、撮り直しなどで今日の日付を使いたい場合のため。
+    """
+    if file_date == today:
+        return candidates
+
+    # YYYY-MM-DD と、学習系ルールの YYYY-MM の両方を対象にする
+    prefixes = [(today, file_date), (today[:7], file_date[:7])]
+
+    matches = []
+    for index, name in enumerate(candidates):
+        # 長い YYYY-MM-DD から先に見て、1候補につき1回だけ差し替える
+        for old, new in prefixes:
+            if name.startswith(old):
+                matches.append((index, old, new))
+                break
+
+    result = list(candidates)
+    for index, old, new in matches[:-1]:
+        result[index] = new + result[index][len(old):]
+    return result
+
+
 def build_candidates(filepath, prompt_template):
     """OCR/テキスト抽出からファイル名候補までをまとめる。監視・手動の共通処理。"""
     print("🔍 テキストを抽出中...")
     text = extract_text(filepath)
 
     print("🧠 LLMへファイル名候補をリクエスト中...")
-    return get_filename_candidates(text, prompt_template)
+    candidates = get_filename_candidates(text, prompt_template)
+    if not candidates:
+        return candidates
+
+    return prefer_file_date(
+        candidates, get_file_date(filepath), datetime.now().strftime("%Y-%m-%d")
+    )
 
 
 def process_screenshot(filepath, config):


### PR DESCRIPTION
過去に撮ったスクショをリネームすると候補が全て本日の日付になる問題。元ファイルの日付を優先しつつ、本日の日付も選べるようにした。

Closes #24

## 変更点

`main.py` に3つ追加した。

| 関数 | 役割 |
| --- | --- |
| `extract_date_from_name()` | ファイル名の日付を拾う（`2024-12-13` / `2024_12_13` / `20241213`） |
| `get_file_date()` | ファイル名の日付を優先、無ければ作成日時（`st_birthtime`） |
| `prefer_file_date()` | 本日の日付の候補を、最後の1件を残してファイルの日付に差し替える |

### 差し替えの挙動

`スクリーンショット 2024-12-13 19.43.39.png` の場合。

```
before                                         after
2026-09-01__YouTube__月曜から夜ふかし_..._Clip     2024-12-13__YouTube__月曜から夜ふかし_..._Clip
2026-09-01__YouTube__月曜から夜ふかし_..._Capture  2024-12-13__YouTube__月曜から夜ふかし_..._Capture
2026-09-01__Other__建築業界の仕事の流れ_Summary    2026-09-01__Other__建築業界の仕事の流れ_Summary
```

本日の日付の候補を1件残すのは、撮り直しなどで今日の日付を使いたい場合があるため。

**OCR本文から日付を読み取れた候補は触らない。** 領収書のように内容に日付が写っている場合、そちらの方が正しく、書き換えると壊れる。本日の日付になっていない候補＝内容由来と判定できる。

プロンプトは変更していない。LLM の遵守に依存させず、後処理で決定的に行う。

## 確認したこと

依存モジュールをスタブ化して14件のケースを検証、全て通過。

- ファイル名からの日付抽出: 和名スクショ / 英名 Screenshot / `IMG_2024_12_13` / `IMG_20241213` / 既存の命名規則 / 日付なし / 不正な日付（`20249999`）/ 金額の誤検出（`11500JPY`）
- 差し替え: 3件とも本日 → 2件差し替え / 内容由来の日付は不変 / 本日の候補が1件だけなら残す / `YYYY-MM` 形式（学習系ルール）/ ファイルの日付＝本日なら何もしない

実機のファイルで `get_file_date()` も確認。

```
2026-09-01  <- Screenshot 2026-09-01 at 23.33.31.png
2026-08-17  <- 2026-08-17__Chrome__Browser_Screenshot_Capture.png
```

**未確認**: 実際にダイアログを開いての表示。ロジックは上記で検証済みだが、Gemini を通した実物の候補では見ていない。

## 対象外

API障害時の連番フォールバック（`get_next_sequence_name`）は本日の日付のまま。日付が意味を持たない退避処理のため。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013sRAJor8Z5Yf41NCEKYJtT
