### PR TITLE
docs(render): ダイアログ画像の生成スクリプトを追加する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ macOSで撮影したスクリーンショットを `watchdog` で検知し、Vis
 | `config.yaml` | 全ての設定値と命名規則プロンプト |
 | `setup.sh` | 仮想環境・`.env`・launchd常駐・Finderの右クリック登録のセットアップ |
 | `requirements.txt` | 依存パッケージ。READMEと二重管理しない |
-| `docs/` | READMEに貼るダイアログの画像 |
+| `docs/` | READMEに貼るダイアログの画像と、その生成スクリプト（`render.py`） |
 
 **設定値をコードにハードコードしないこと。** 監視先・保存先・タイムアウト・モデル名・命名規則は全て `config.yaml` に集約する。
 

--- a/docs/render.py
+++ b/docs/render.py
@@ -1,0 +1,131 @@
+"""README に貼るリネームダイアログの画像を生成する。
+
+    .venv/bin/python docs/render.py
+
+`docs/dialog-light.png` と `docs/dialog-dark.png` を上書きする。
+`popup_ui.py` の見た目を変えたら実行し直すこと。
+"""
+import os
+import sys
+import tempfile
+
+# 実画面を開かずに描画する。ヘッドレスでも動く
+os.environ["QT_QPA_PLATFORM"] = "offscreen"
+
+DOCS_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(DOCS_DIR))
+
+from PyQt6.QtGui import QColor, QFont, QPainter, QPalette, QPixmap
+from PyQt6.QtWidgets import QApplication
+
+from popup_ui import RenameDialog
+
+WINDOW_SIZE = (1160, 720)
+
+# 候補は config.yaml の命名規則（3. 自動車関連）に沿った架空の例
+CANDIDATES = [
+    "2026-05-06__Car__Camry_ACV40R_整備部品_0450.00AUD_Receipt",
+    "2026-05-06__Car__Camry_ACV40R_ブレーキパッド交換_0450.00AUD_Receipt",
+    "2026-05-06__Other__Northside_Auto_Service_請求書_Summary",
+]
+
+# current_theme() は QPalette の地の色の明るさでライト／ダークを判定する
+BACKGROUNDS = {"light": "#ececec", "dark": "#1e1e1e"}
+
+
+def draw_sample_invoice(path):
+    """プレビューに写す画像を作る。
+
+    実際のスクリーンショットを README に載せないよう、その場で架空の請求書を描く。
+    シートの下から覗く部分にも中身が来るよう、横長で全体に内容を散らす。
+    """
+    pixmap = QPixmap(1600, 1000)
+    pixmap.fill(QColor("#ffffff"))
+    painter = QPainter(pixmap)
+
+    painter.fillRect(0, 0, 1600, 92, QColor("#1f2937"))
+    painter.setPen(QColor("#ffffff"))
+    painter.setFont(QFont("Helvetica", 26, QFont.Weight.Bold))
+    painter.drawText(56, 60, "Northside Auto Service")
+    painter.setFont(QFont("Helvetica", 20))
+    painter.drawText(1290, 60, "Invoice A-20260506-118")
+
+    painter.setPen(QColor("#111111"))
+    painter.setFont(QFont("Helvetica", 40, QFont.Weight.Bold))
+    painter.drawText(56, 200, "TAX INVOICE")
+    painter.setFont(QFont("Helvetica", 22))
+    painter.setPen(QColor("#555555"))
+    painter.drawText(56, 250, "Date  06 May 2026")
+    painter.drawText(56, 290, "Vehicle  Toyota Camry ACV40R")
+
+    painter.fillRect(56, 350, 1488, 56, QColor("#f3f4f6"))
+    painter.setPen(QColor("#333333"))
+    painter.setFont(QFont("Helvetica", 20, QFont.Weight.Bold))
+    for x, label in ((80, "Description"), (900, "Qty"), (1080, "Unit"), (1330, "Amount")):
+        painter.drawText(x, 388, label)
+
+    painter.setFont(QFont("Helvetica", 21))
+    rows = [
+        ("Brake pad set (front)", "2", "90.00", "180.00"),
+        ("Oil filter", "1", "42.00", "42.00"),
+        ("Engine oil 5W-30  5L", "1", "98.00", "98.00"),
+        ("Labour  1.5h", "1", "130.00", "130.00"),
+    ]
+    y = 470
+    for label, qty, unit, amount in rows:
+        painter.setPen(QColor("#111111"))
+        painter.drawText(80, y, label)
+        painter.drawText(900, y, qty)
+        painter.drawText(1080, y, unit)
+        painter.drawText(1330, y, amount)
+        painter.setPen(QColor("#e5e7eb"))
+        painter.drawLine(56, y + 22, 1544, y + 22)
+        y += 78
+
+    painter.setPen(QColor("#111111"))
+    painter.setFont(QFont("Helvetica", 28, QFont.Weight.Bold))
+    painter.drawText(1080, y + 60, "TOTAL")
+    painter.drawText(1280, y + 60, "450.00 AUD")
+
+    painter.setPen(QColor("#888888"))
+    painter.setFont(QFont("Helvetica", 18))
+    painter.drawText(56, 960, "Thank you for your business.")
+    painter.end()
+
+    pixmap.save(path)
+
+
+def render(app, mode, preview_path, out_path):
+    palette = QPalette(app.style().standardPalette())
+    palette.setColor(QPalette.ColorRole.Window, QColor(BACKGROUNDS[mode]))
+    app.setPalette(palette)
+
+    dialog = RenameDialog(
+        CANDIDATES, preview_path, 10, None, os.path.expanduser("~/Documents/Screenshots")
+    )
+    dialog.resize(*WINDOW_SIZE)
+    dialog.show()
+    for _ in range(3):
+        app.processEvents()
+
+    # show() だけではプレビューの配置と拡縮が走らず、中身が空のまま写る
+    dialog._layout_children()
+    dialog.preview._rescale()
+    app.processEvents()
+
+    dialog.grab().save(out_path)
+    dialog.close()
+    print(f"{mode}: {out_path}")
+
+
+def main():
+    app = QApplication([])
+    with tempfile.TemporaryDirectory() as tmp:
+        preview_path = os.path.join(tmp, "sample-invoice.png")
+        draw_sample_invoice(preview_path)
+        for mode in BACKGROUNDS:
+            render(app, mode, preview_path, os.path.join(DOCS_DIR, f"dialog-{mode}.png"))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
`docs/dialog-light.png` / `docs/dialog-dark.png` を作り直せるようにする。

Closes #29

## 変更点

`docs/render.py` を追加。

```bash
.venv/bin/python docs/render.py
```

- `QT_QPA_PLATFORM=offscreen` で `RenameDialog` を描画し、`docs/` に2枚を上書きする
- ライト／ダークは `QPalette` の地の色を差し替えて `current_theme()` に判定させる
- プレビューに写す請求書はスクリプト内で描画する。実際のスクリーンショットを README に載せないため。一時ディレクトリに書くのでリポジトリには残らない
- シートの下から覗く部分にも中身が来るよう、横長で全体に内容を散らしてある

`show()` だけではプレビューの配置と拡縮が走らず中身が空のまま写るため、`_layout_children()` と `_rescale()` を明示的に呼んでいる。private を触っているが、オフスクリーンでレイアウトを確定させる他の手段が無い。

## 確認したこと

スクリプトを実行し、**生成結果がリポジトリ内の既存画像とバイト一致すること**を確認した（`git status` に PNG の変更が出ない）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013sRAJor8Z5Yf41NCEKYJtT